### PR TITLE
Fix main and browser field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "url": "https://github.com/storybookjs/addon-svelte-csf"
   },
   "license": "MIT",
-  "main": "dist/preset.js",
+  "main": "dist/preset",
+  "browser": "dist/index.js",
   "files": [
     "dist/**/*",
     "README.md",


### PR DESCRIPTION
Fix #6 

Added a main field referencing the preset.js for the backend, and a browser field referencing the svelte components for the client.