### PR TITLE
Fix names with special char at end

### DIFF
--- a/src/parser/extract-id.test.js
+++ b/src/parser/extract-id.test.js
@@ -4,6 +4,9 @@ describe('extract-id', () => {
   test('name with spaces', () => {
     expect(extractId({ name: 'Name with spaces' })).toBe('NameWithSpaces');
   });
+  test('name with parenthesis', () => {
+    expect(extractId({ name: 'Name with (parenthesis)' })).toBe('NameWithParenthesis');
+  });
   test('duplicates id', () => {
     expect(extractId({ name: 'Button' }, ['Button'])).toBe('Button77471352');
   });

--- a/src/parser/extract-id.ts
+++ b/src/parser/extract-id.ts
@@ -24,7 +24,7 @@ export function extractId(
     return id;
   }
 
-  let generated = name.replace(/\W+(.)/g, (_, chr) => chr.toUpperCase());
+  let generated = name.replace(/\W+(.|$)/g, (_, chr) => chr.toUpperCase());
   if (allocatedIds.indexOf(generated) >= 0) {
     logger.warn(`Story name conflict with exports - Please add an explicit id for story ${name}`);
     generated += hashCode(name);


### PR DESCRIPTION
Fix #54

Id for "Name with (Parenthesis)" was "NameWithParenthesis)" which is not a valid id.