### PR TITLE
Make `svelte-loader` optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "svelte-loader": "^3.1.2"
   },
   "peerDependenciesMeta": {
-    "svelte": {
+    "svelte-loader": {
       "optional": true
     }
   },


### PR DESCRIPTION
Closes https://github.com/storybookjs/addon-svelte-csf/issues/60

It would be nice not to require `svelte-loader` (webpack support) for Vite projects. You need either it or `@storybook/builder-vite`, but it doesn't matter which one

I'm also removing `svelte` as optional as it seems like something you kind of need in a Svelte project though I don't really have strong feelings in whether it's listed as optional or not

Companion PR in https://github.com/storybookjs/storybook/pull/18645