### PR TITLE
Make types compatible with TypeScript `strict` mode

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -58,10 +58,10 @@ export class Meta extends SvelteComponentTyped<BaseMeta<any> & BaseAnnotations<a
 /**
  * Story.
  */
-export class Story extends SvelteComponentTyped<StoryProps, {}, Slots> {}
+export class Story extends SvelteComponentTyped<StoryProps, any, Slots> { }
 /**
  * Template.
  * 
  * Allow to reuse definition between stories.
  */
-export class Template extends SvelteComponentTyped<TemplateProps, {}, Slots> {}
+export class Template extends SvelteComponentTyped<TemplateProps, any, Slots> { }


### PR DESCRIPTION
see #73

changed the events type parameter to any for Template and Story, since those are the default, as per [this line](https://github.com/sveltejs/svelte/blob/master/src/runtime/internal/dev.ts#L213)