### PR TITLE
Require Storybook v7 in v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ It supports:
 
 # Getting Started
 
-1. Add '@storybook/addon-svelte-csf' to your dev dependencies
-2. In `.storybook/main.js`, add `*.stories.svelte` to the stories patterns
-3. In `.storybook/main.js`, add `@storybook/addon-svelte-csf` to the addons array
+1. `npm install --save-dev @storybook/addon-svelte-csf` or `yarn add --dev @storybook/addon-svelte-csf`
+2. In `.storybook/main.js`, add `@storybook/addon-svelte-csf` to the addons array
+3. In `.storybook/main.js`, add `*.stories.svelte` to the stories patterns
+
+An example `main.js` configuration could look like this:
+
+```js
+module.exports = {
+  stories: ['../src/**/*.stories.@(js|jsx|ts|tsx|svelte)'],
+  addons: [
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@storybook/addon-interactions',
+    '@storybook/addon-svelte-csf',
+  ],
+  framework: '@storybook/svelte-vite',
+};
+```
+
+> **Warning**
+> v3 and above of this addon requires at least Storybook v7. If you're using Storybook between v6.4.20 and v7.0.0, you should instead use v2 of this addon with `npm install --save-dev @storybook/addon-svelte-csf@^2.0.10` or `yarn add --dev @storybook/addon-svelte-csf@^2.0.10`

--- a/package.json
+++ b/package.json
@@ -76,8 +76,8 @@
     "vite": "^3.1.4"
   },
   "peerDependencies": {
-    "@storybook/svelte": ">=6.4.20",
-    "@storybook/theming": ">=6.4.20",
+    "@storybook/svelte": ">=7.0.0",
+    "@storybook/theming": ">=7.0.0",
     "@sveltejs/vite-plugin-svelte": "^1.0.0",
     "svelte": "^3.50.0",
     "svelte-loader": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@sveltejs/vite-plugin-svelte": "^1.0.0 || ^2.0.0",
     "svelte": "^3.50.0",
     "svelte-loader": "^3.1.2",
-    "vite": ">=3.0.0"
+    "vite": "^3.0.0 || ^4.0.0"
   },
   "peerDependenciesMeta": {
     "@sveltejs/vite-plugin-svelte": {

--- a/package.json
+++ b/package.json
@@ -76,9 +76,9 @@
     "vite": "^3.1.4"
   },
   "peerDependencies": {
-    "@storybook/svelte": ">=7.0.0",
-    "@storybook/theming": ">=7.0.0",
-    "@sveltejs/vite-plugin-svelte": "^1.0.0",
+    "@storybook/svelte": "^7.0.0-beta",
+    "@storybook/theming": "^7.0.0-beta",
+    "@sveltejs/vite-plugin-svelte": "^1.0.0 || ^2.0.0",
     "svelte": "^3.50.0",
     "svelte-loader": "^3.1.2",
     "vite": ">=3.0.0"


### PR DESCRIPTION
The changes planned for v3, #69 and #72 requires Storybook v7. This PR upgrades the peer dependencies for that.

Same PR on the other end: https://github.com/storybookjs/storybook/pull/20280. Together they (hopefully) fix #82

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.0.0--canary.81.9c0f315.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-svelte-csf@3.0.0--canary.81.9c0f315.0
  # or 
  yarn add @storybook/addon-svelte-csf@3.0.0--canary.81.9c0f315.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
