### PR TITLE
Support newest ESM-only `@sveltejs/vite-plugin` 

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,5 +1,8 @@
 module.exports = {
-  presets: [['@babel/preset-env', { targets: { node: '16' } }], '@babel/preset-typescript'],
+  presets: [
+    ['@babel/preset-env', { targets: { node: '16' }, modules: false }],
+    '@babel/preset-typescript',
+  ],
   plugins: ['@babel/plugin-transform-runtime'],
   env: {
     esm: {

--- a/src/preset/index.js
+++ b/src/preset/index.js
@@ -41,7 +41,7 @@ export async function viteFinal(config, options) {
     }
   }
 
-  const { default: svelteCsfPlugin } = await import('../plugins/vite-svelte-csf');
+  const svelteCsfPlugin = (await import('../plugins/vite-svelte-csf.js')).default.default;
   plugins.push(svelteCsfPlugin(svelteConfig));
 
   return {


### PR DESCRIPTION
This PR changes the babel config to not transpile dynamic imports to requires, because `@sveltejs/vite-plugin@2` is ESM only, so it broke with:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in .../node_modules/@sveltejs/vite-plugin-svelte/package.json
```

Have only tested in a Vite setup, need to test this out in a fresh Webpack5 setup as well.