### PR TITLE
Trigger release

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ module.exports = {
 ```
 
 > **Warning**
-> v3 and above of this addon requires at least Storybook v7. If you're using Storybook between v6.4.20 and v7.0.0, you should instead use v2 of this addon with `npm install --save-dev @storybook/addon-svelte-csf@^2.0.10` or `yarn add --dev @storybook/addon-svelte-csf@^2.0.10`
+> v3 and above of this addon requires at least Storybook v7.0.0. If you're using Storybook between v6.4.20 and v7.0.0, you should instead use v2 of this addon with `npm install --save-dev @storybook/addon-svelte-csf@^2.0.10` or `yarn add --dev @storybook/addon-svelte-csf@^2.0.10`


### PR DESCRIPTION
Making a small change to the README, to try to trigger a release for https://github.com/storybookjs/addon-svelte-csf/pull/84, which failed to release properly.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.11--canary.85.284b0e8.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-svelte-csf@2.0.11--canary.85.284b0e8.0
  # or 
  yarn add @storybook/addon-svelte-csf@2.0.11--canary.85.284b0e8.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
