### PR TITLE
fix: preprocess svelte file during indexing

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.5",
+    "fs-extra": "^11.1.1",
     "magic-string": "^0.26.6",
     "ts-dedent": "^2.0.0"
   },

--- a/src/config-loader.js
+++ b/src/config-loader.js
@@ -17,7 +17,7 @@ export async function loadSvelteConfig() {
   const configFile = await findSvelteConfig();
 
   // no need to throw error since we handle projects without config files
-  if (configFile !== undefined) {
+  if (configFile === undefined) {
     return undefined;
   }
 

--- a/src/config-loader.js
+++ b/src/config-loader.js
@@ -1,0 +1,171 @@
+// This file is a rewrite of `@sveltejs/vite-plugin-svelte` without the `Vite`
+// parts: https://github.com/sveltejs/vite-plugin-svelte/blob/e8e52deef93948da735c4ab69c54aced914926cf/packages/vite-plugin-svelte/src/utils/load-svelte-config.ts
+import { logger } from '@storybook/client-logger';
+import { createRequire } from 'module';
+import path from 'path';
+import fs from 'fs';
+import { pathToFileURL, fileURLToPath } from 'url';
+
+/**
+ * Try find svelte config and then load it.
+ *
+ * @returns {import('@sveltejs/kit').Config}
+ * Returns the svelte configuration object.
+ */
+export async function loadSvelteConfig() {
+  const configFile = findSvelteConfig();
+  let err;
+
+  // try to use dynamic import for svelte.config.js first
+  if (configFile.endsWith('.js') || configFile.endsWith('.mjs')) {
+    try {
+      return importSvelteOptions(configFile);
+    } catch (e) {
+      logger.error(`failed to import config ${configFile}`, e);
+      err = e;
+    }
+  }
+  // cjs or error with dynamic import
+  if (configFile.endsWith('.js') || configFile.endsWith('.cjs')) {
+    try {
+      return requireSvelteOptions(configFile);
+    } catch (e) {
+      logger.error(`failed to require config ${configFile}`, e);
+      if (!err) {
+        err = e;
+      }
+    }
+  }
+  // failed to load existing config file
+  throw new Error(`failed to load config ${configFile}`, { cause: err });
+}
+
+const importSvelteOptions = (() => {
+  // hide dynamic import from ts transform to prevent it turning into a require
+  // see https://github.com/microsoft/TypeScript/issues/43329#issuecomment-811606238
+  // also use timestamp query to avoid caching on reload
+  const dynamicImportDefault = new Function(
+    'path',
+    'timestamp',
+    'return import(path + "?t=" + timestamp).then(m => m.default)'
+  );
+
+  /**
+   * Try import specified svelte configuration.
+   *
+   * @param {string} configFile
+   * Absolute path of the svelte config file to import.
+   *
+   * @returns {import('@sveltejs/kit').Config}
+   * Returns the svelte configuration object.
+   */
+  return async (configFile) => {
+    const result = await dynamicImportDefault(
+      pathToFileURL(configFile).href,
+      fs.statSync(configFile).mtimeMs
+    );
+
+    if (result != null) {
+      return { ...result, configFile };
+    }
+    throw new Error(`invalid export in ${configFile}`);
+  };
+})();
+
+const requireSvelteOptions = (() => {
+  /** @type {NodeRequire} */
+  let esmRequire;
+
+  /**
+   * Try import specified svelte configuration.
+   *
+   * @param {string} configFile
+   * Absolute path of the svelte config file to require.
+   *
+   * @returns {import('@sveltejs/kit').Config}
+   * Returns the svelte configuration object.
+   */
+  return (configFile) => {
+    // identify which require function to use (esm and cjs mode)
+    const requireFn = import.meta.url
+      ? (esmRequire = esmRequire ?? createRequire(import.meta.url))
+      : require;
+
+    // avoid loading cached version on reload
+    delete requireFn.cache[requireFn.resolve(configFile)];
+    const result = requireFn(configFile);
+
+    if (result != null) {
+      return { ...result, configFile };
+    }
+    throw new Error(`invalid export in ${configFile}`);
+  };
+})();
+
+/**
+ * Try find svelte config. First in current working dir otherwise try to
+ * founding it by climbing up the directory tree.
+ *
+ * @returns {string}
+ * Returns an array containing all available config files.
+ */
+function findSvelteConfig() {
+  const lookupDir = process.cwd();
+  let configFiles = getConfigFiles(lookupDir);
+
+  if (configFiles.length === 0) {
+    configFiles = getConfigFilesUp();
+  }
+  if (configFiles.length === 0) {
+    throw new Error('no svelte config found');
+  } else if (configFiles.length > 1) {
+    logger.warn(
+      `found more than one svelte config file, using ${configFiles[0]}. ` +
+        'you should only have one!',
+      configFiles
+    );
+  }
+  return configFiles[0];
+}
+
+/**
+ * Gets the file path of the svelte config by walking up the tree.
+ * Returning the first found. Should solves most of monorepos with
+ * only one config at workspace root.
+ *
+ * @returns {string[]}
+ * Returns an array containing all available config files.
+ */
+async function getConfigFilesUp() {
+  const importPath = fileURLToPath(import.meta.url);
+  const pathChunks = path.dirname(importPath).split(path.sep);
+
+  while (pathChunks.length) {
+    pathChunks.pop();
+
+    const parentDir = pathChunks.join(path.posix.sep);
+    const configFiles = getConfigFiles(parentDir);
+
+    if (configFiles.length !== 0) {
+      return configFiles;
+    }
+  }
+  return [];
+}
+
+/**
+ * Gets all svelte config from a specified `lookupDir`.
+ *
+ * @param {string} lookupDir
+ * Directory in which to look for svelte files.
+ *
+ * @returns {string[]}
+ * Returns an array containing all available config files.
+ */
+function getConfigFiles(lookupDir) {
+  return knownConfigFiles
+    .map((candidate) => path.resolve(lookupDir, candidate))
+    .filter((file) => fs.existsSync(file));
+}
+
+const knownConfigFiles = ['js', 'cjs', 'mjs'].map((ext) => `svelte.config.${ext}`);

--- a/src/config-loader.js
+++ b/src/config-loader.js
@@ -136,7 +136,7 @@ function findSvelteConfig() {
  * @returns {string[]}
  * Returns an array containing all available config files.
  */
-async function getConfigFilesUp() {
+function getConfigFilesUp() {
   const importPath = fileURLToPath(import.meta.url);
   const pathChunks = path.dirname(importPath).split(path.sep);
 

--- a/src/preset/indexer.js
+++ b/src/preset/indexer.js
@@ -1,6 +1,6 @@
 import * as svelte from 'svelte/compiler';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import fs from 'fs-extra';
 import { extractStories } from '../parser/extract-stories';
 
@@ -9,7 +9,7 @@ export async function svelteIndexer(fileName, { makeTitle }) {
   const optionsPath = await findUp('svelte.config.js');
 
   if (optionsPath) {
-    const { default: svelteOptions } = await import(`file:///${optionsPath}`);
+    const { default: svelteOptions } = await import(pathToFileURL(optionsPath));
     if (svelteOptions && svelteOptions.preprocess) {
       code = (await svelte.preprocess(code, svelteOptions.preprocess, { filename: fileName })).code;
     }

--- a/src/preset/indexer.js
+++ b/src/preset/indexer.js
@@ -34,7 +34,8 @@ async function findUp(name) {
 
   while (chunks.length) {
     const filePath = path.resolve(chunks.join(path.posix), `../${name}`);
-    const pathExist = fs.pathExists(filePath, name);
+    // eslint-disable-next-line no-await-in-loop
+    const pathExist = await fs.pathExists(filePath);
 
     if (pathExist) {
       return filePath;

--- a/src/preset/indexer.js
+++ b/src/preset/indexer.js
@@ -1,5 +1,6 @@
 import * as svelte from 'svelte/compiler';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import fs from 'fs-extra';
 import { extractStories } from '../parser/extract-stories';
 
@@ -28,7 +29,8 @@ export async function svelteIndexer(fileName, { makeTitle }) {
 }
 
 async function findUp(name) {
-  const chunks = __dirname.split(path.sep);
+  const importPath = fileURLToPath(import.meta.url);
+  const chunks = path.dirname(importPath).split(path.sep);
 
   while (chunks.length) {
     const filePath = path.resolve(chunks.join(path.posix), `../${name}`);

--- a/src/preset/indexer.js
+++ b/src/preset/indexer.js
@@ -5,7 +5,7 @@ import { loadSvelteConfig } from '../config-loader';
 
 export async function svelteIndexer(fileName, { makeTitle }) {
   let code = (await fs.readFile(fileName, 'utf-8')).toString();
-  const svelteOptions = loadSvelteConfig();
+  const svelteOptions = await loadSvelteConfig();
 
   if (svelteOptions && svelteOptions.preprocess) {
     code = (await svelte.preprocess(code, svelteOptions.preprocess, { filename: fileName })).code;

--- a/src/preset/indexer.js
+++ b/src/preset/indexer.js
@@ -33,7 +33,7 @@ async function findUp(name) {
   const chunks = path.dirname(importPath).split(path.sep);
 
   while (chunks.length) {
-    const filePath = path.resolve(chunks.join(path.posix), `../${name}`);
+    const filePath = path.resolve(chunks.join(path.posix.sep), `../${name}`);
     // eslint-disable-next-line no-await-in-loop
     const pathExist = await fs.pathExists(filePath);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7784,6 +7784,15 @@ fs-extra@^10.1.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
+fs-extra@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.1.tgz#da69f7c39f3b002378b0954bb6ae7efdc0876e2d"
+  integrity sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-extra@^9.0.1:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"


### PR DESCRIPTION
Closes https://github.com/storybookjs/addon-svelte-csf/issues/88

It fixes the issue where svelte files wasn't pre-processed during indexing making it impossible to load `*.stories.svelte` files with `lang="ts"` for example. Indeed this implementation is a very naïve approach. It walking up the directory tree to look for the first `svelte.config.js` file. It should solve 90% of the cases since svelte apps don't work without it. Indeed projects with exotic location or specifying a new svelte config in the storybook main file are not taken into account here. 

Hope it helps
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.12--canary.94.71b3707.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-svelte-csf@2.0.12--canary.94.71b3707.0
  # or 
  yarn add @storybook/addon-svelte-csf@2.0.12--canary.94.71b3707.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
