### PR TITLE
fix: imports on index.d.ts file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import type { SvelteComponentTyped, SvelteComponent } from 'svelte';
-import type { BaseMeta, BaseAnnotations, StoryContext } from '@storybook/addons';
+import type { Addon_BaseMeta as BaseMeta, Addon_BaseAnnotations as BaseAnnotations, StoryContext } from '@storybook/types';
 
 
 type DecoratorReturnType = void|SvelteComponent|{


### PR DESCRIPTION
This should fix https://github.com/storybookjs/addon-svelte-csf/issues/96 as the types don't exist anymore in '@storybook/addons'