### PR TITLE
types: use `WebRenderer` type as new `Addon_BaseAnnotations` template variable

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,13 @@
 import type { SvelteComponentTyped, SvelteComponent } from 'svelte';
-import type { Addon_BaseMeta as BaseMeta, Addon_BaseAnnotations as BaseAnnotations, StoryContext } from '@storybook/types';
+import type { Addon_BaseMeta as BaseMeta, Addon_BaseAnnotations as BaseAnnotations, StoryContext, WebRenderer } from '@storybook/types';
 
 
-type DecoratorReturnType = void|SvelteComponent|{
+type DecoratorReturnType = void | SvelteComponent | {
     Component: any,
     props?: any
 }
 
-interface StoryProps extends BaseAnnotations<any, DecoratorReturnType> {
+interface StoryProps extends BaseAnnotations<any, DecoratorReturnType, WebRenderer> {
     /**
      * Id of the story.
      * 
@@ -32,7 +32,7 @@ interface StoryProps extends BaseAnnotations<any, DecoratorReturnType> {
      * If source is true, then the source of the story will be used instead.
      * If source is a string, it replaces the source of the story.
      */
-    source?: boolean|string
+    source?: boolean | string
 }
 
 interface TemplateProps extends BaseAnnotations<any, DecoratorReturnType> {
@@ -54,7 +54,7 @@ interface Slots {
 /**
  * Meta.
  */
-export class Meta extends SvelteComponentTyped<BaseMeta<any> & BaseAnnotations<any, DecoratorReturnType>> {}
+export class Meta extends SvelteComponentTyped<BaseMeta<any> & BaseAnnotations<any, DecoratorReturnType>> { }
 /**
  * Story.
  */

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@storybook/svelte": "^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0",
     "@storybook/svelte-webpack5": "^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0",
     "@storybook/testing-library": "^0.0.13",
-    "@storybook/types": "7.1.0-alpha.26",
+    "@storybook/types": "^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0",
     "auto": "^10.43.0",
     "babel-jest": "^29.5.0",
     "babel-loader": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@storybook/svelte": "^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0",
     "@storybook/svelte-webpack5": "^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0",
     "@storybook/testing-library": "^0.0.13",
+    "@storybook/types": "7.1.0-alpha.26",
     "auto": "^10.43.0",
     "babel-jest": "^29.5.0",
     "babel-loader": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3263,6 +3263,11 @@
   resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-7.0.0-rc.11.tgz#9f8d43f5a78e3d286b0399e0188beac32e9a10a5"
   integrity sha512-MyY8tZPwCW9JjOvpFCDWZDqqnh0DnDt/iwOyFr9W4b5K/oGkTtZaVOMp0pq6nhjhDEOIp4p4MnSu/Sh1qZroKw==
 
+"@storybook/channels@7.1.0-alpha.26":
+  version "7.1.0-alpha.26"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-7.1.0-alpha.26.tgz#6911c55d507beda8e573cd5dbf24cf34bdce1f04"
+  integrity sha512-acR7qdiBJv3vQfAfubtR3/jJmzav9JRmOLg1tDAFNj1H8DHT+qweTxbT6hyo3Ri8HBsLtZcX7GbZfZ2EYjF/GA==
+
 "@storybook/cli@7.0.0-rc.11":
   version "7.0.0-rc.11"
   resolved "https://registry.yarnpkg.com/@storybook/cli/-/cli-7.0.0-rc.11.tgz#1ee39807173ffe5d6586b0bf8d487553b954b4d5"
@@ -3817,6 +3822,16 @@
   integrity sha512-y+9bqsE7Pzl74F1Q3EJVQzChyclWL/FPCYOeBmwpY2O++MJKSBJMauCLcGDztNc645wVGvfQXW016b3fbBELgA==
   dependencies:
     "@storybook/channels" "7.0.0-rc.11"
+    "@types/babel__core" "^7.0.0"
+    "@types/express" "^4.7.0"
+    file-system-cache "^2.0.0"
+
+"@storybook/types@7.1.0-alpha.26":
+  version "7.1.0-alpha.26"
+  resolved "https://registry.yarnpkg.com/@storybook/types/-/types-7.1.0-alpha.26.tgz#409501550fa0081650d525006cab6c41fdf75af1"
+  integrity sha512-InPzba92gheqHLMIFuQsvScX8YVWPPh4BYIY5ZuKQA/CoU7ImQ32WKtm3GwbMQT8zdXocqNjHoMx91DxKYtehw==
+  dependencies:
+    "@storybook/channels" "7.1.0-alpha.26"
     "@types/babel__core" "^7.0.0"
     "@types/express" "^4.7.0"
     file-system-cache "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3263,10 +3263,10 @@
   resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-7.0.0-rc.11.tgz#9f8d43f5a78e3d286b0399e0188beac32e9a10a5"
   integrity sha512-MyY8tZPwCW9JjOvpFCDWZDqqnh0DnDt/iwOyFr9W4b5K/oGkTtZaVOMp0pq6nhjhDEOIp4p4MnSu/Sh1qZroKw==
 
-"@storybook/channels@7.1.0-alpha.26":
-  version "7.1.0-alpha.26"
-  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-7.1.0-alpha.26.tgz#6911c55d507beda8e573cd5dbf24cf34bdce1f04"
-  integrity sha512-acR7qdiBJv3vQfAfubtR3/jJmzav9JRmOLg1tDAFNj1H8DHT+qweTxbT6hyo3Ri8HBsLtZcX7GbZfZ2EYjF/GA==
+"@storybook/channels@7.0.20":
+  version "7.0.20"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-7.0.20.tgz#a681c3d463b4099b001dae9edeb3a607a8f4854a"
+  integrity sha512-AL5GGSQ8WTDUoh3gitKEzo3fu7Vq5okXq2pAknAZlQA2Oio+HHO5nMeXvOfGdvo/tzbpNE3n5utmCJz006xrCA==
 
 "@storybook/cli@7.0.0-rc.11":
   version "7.0.0-rc.11"
@@ -3826,12 +3826,12 @@
     "@types/express" "^4.7.0"
     file-system-cache "^2.0.0"
 
-"@storybook/types@7.1.0-alpha.26":
-  version "7.1.0-alpha.26"
-  resolved "https://registry.yarnpkg.com/@storybook/types/-/types-7.1.0-alpha.26.tgz#409501550fa0081650d525006cab6c41fdf75af1"
-  integrity sha512-InPzba92gheqHLMIFuQsvScX8YVWPPh4BYIY5ZuKQA/CoU7ImQ32WKtm3GwbMQT8zdXocqNjHoMx91DxKYtehw==
+"@storybook/types@^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0":
+  version "7.0.20"
+  resolved "https://registry.yarnpkg.com/@storybook/types/-/types-7.0.20.tgz#6aadc565f5894512b7f8da2aea9cac9448160519"
+  integrity sha512-Z7RhHRnhrPd2jXPZtjbOILj1QgylqlsD3cFIYMcSz3yvUvxLRx3BKCftXyFbIuxr0QoCJE38adRp7YGO9uJnQQ==
   dependencies:
-    "@storybook/channels" "7.1.0-alpha.26"
+    "@storybook/channels" "7.0.20"
     "@types/babel__core" "^7.0.0"
     "@types/express" "^4.7.0"
     file-system-cache "^2.0.0"


### PR DESCRIPTION
Fixes #105 

See @storybook repository PR: [here](https://github.com/storybookjs/storybook/pull/22771).

Here I'm using the new template variable for the `Addon_BaseAnnotations` alias `BaseAnnotations` using the `WebRenderer` type to have a known type for the `canvasElement`. 

This is a preliminary PR since the version `7.1.0` it's not released yet. 

Let me know about anything I have missed. 