### PR TITLE
fix: swap order of types to avoid module not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "svelte": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "svelte": "./dist/index.js"
     },
     "./preset": {
       "types": "./dist/preset/index.d.ts",


### PR DESCRIPTION
Right now the version 3.0.5 gives you errors in VSCode because the types are exported last in the main export of `package.json`.

Checking the package on publint you can see that this will break typings for TS.

https://publint.dev/@storybook/addon-svelte-csf@3.0.5

I checked locally that swapping the order fixes the problem.