### PR TITLE
Fix missing types by adding back `main` and `types` fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   },
   "license": "MIT",
   "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
… so TS node10 moduleResolution still works per #116.