### PR TITLE
Fix export condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "svelte": "./dist/index.js"
+      "default": "./dist/index.js"
     },
     "./preset": {
       "types": "./dist/preset/index.d.ts",


### PR DESCRIPTION
Closes https://github.com/storybookjs/addon-svelte-csf/issues/124. You only need to use the `svelte` export condition if you're exporting both compiled and uncompiled `.svelte` files, which is pretty rare
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.0.8--canary.125.172fd41.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-svelte-csf@3.0.8--canary.125.172fd41.0
  # or 
  yarn add @storybook/addon-svelte-csf@3.0.8--canary.125.172fd41.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
