### PR TITLE
docs: remove broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Svelte Story Format
 
-Allows to write your stories in Svelte syntax and compiles it to Storybook's CSF syntax. See the native format tab in the [getting started docs](https://storybook.js.org/docs/svelte/get-started/whats-a-story) for an example.
+Allows you to write your stories in `.svelte` syntax rather than `.js` syntax.
 
 It supports:
 
@@ -9,7 +9,7 @@ It supports:
 - extractions of sources of the stories and compatible with addon-sources
 - decorators
 - knobs, actions, controls
-- storyshots (with a special jest transformation shipped under @storybook/addon-svelte-csf/jest-transform)
+- storyshots (with a special jest transformation shipped under `@storybook/addon-svelte-csf/jest-transform`)
 
 ## Example
 


### PR DESCRIPTION
I think this could be explained more clearly as `.svelte` vs `.js` which removes the need for the broken link explaining what CSF is
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.0.8--canary.126.d24e4fb.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-svelte-csf@3.0.8--canary.126.d24e4fb.0
  # or 
  yarn add @storybook/addon-svelte-csf@3.0.8--canary.126.d24e4fb.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
