### PR TITLE
Require Svelte v4, vite-plugin-svelte v2, Vite v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ It supports:
 </Story>
 ```
 
-# Getting Started
+## Getting Started
 
 1. `npm install --save-dev @storybook/addon-svelte-csf` or `yarn add --dev @storybook/addon-svelte-csf`
 2. In `.storybook/main.js`, add `@storybook/addon-svelte-csf` to the addons array
@@ -64,5 +64,21 @@ module.exports = {
 };
 ```
 
-> **Warning**
-> v3 and above of this addon requires at least Storybook v7. If you're using Storybook between v6.4.20 and v7.0.0, you should instead use v2 of this addon with `npm install --save-dev @storybook/addon-svelte-csf@^2.0.10` or `yarn add --dev @storybook/addon-svelte-csf@^2.0.10`
+## Version Dependencies
+
+### 4.0.0
+
+Version 4 of this addon requires _at least_:
+
+- Storybook v7
+- Svelte v4
+- Vite v4 (if using Vite)
+- `@sveltejs/vite-plugin-svelte` v2 (if using Vite)
+
+If you're using Svelte v3 you can use version `^3.0.0` of this addon instead.
+
+### 3.0.0
+
+Version 3 of this addon requires at least Storybook v7.
+
+If you're using Storybook between v6.4.20 and v7.0.0, you should instead use version `^2.0.0` of this addon.

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "react-dom": "^18.2.0",
     "rimraf": "^3.0.2",
     "storybook": "^7.1.1",
-    "svelte": "^3.55.0",
+    "svelte": "^4.0.0",
     "svelte-check": "^3.5.0",
     "svelte-jester": "^2.3.2",
     "svelte-loader": "^3.1.7",
@@ -99,10 +99,10 @@
   "peerDependencies": {
     "@storybook/svelte": "^7.0.0",
     "@storybook/theming": "^7.0.0",
-    "@sveltejs/vite-plugin-svelte": "^1.0.0 || ^2.0.0",
-    "svelte": "^3.50.0",
+    "@sveltejs/vite-plugin-svelte": "^2.0.0",
+    "svelte": "^4.0.0",
     "svelte-loader": "^3.1.2",
-    "vite": "^3.0.0 || ^4.0.0"
+    "vite": "^4.0.0"
   },
   "peerDependenciesMeta": {
     "@sveltejs/vite-plugin-svelte": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,10 +63,10 @@ devDependencies:
     version: 7.1.1
   '@storybook/svelte':
     specifier: ^7.1.1
-    version: 7.1.1(svelte@3.55.0)
+    version: 7.1.1(svelte@4.0.0)
   '@storybook/svelte-vite':
     specifier: ^7.1.1
-    version: 7.1.1(svelte@3.55.0)(typescript@5.1.6)(vite@4.4.3)
+    version: 7.1.1(svelte@4.0.0)(typescript@5.1.6)(vite@4.4.3)
   '@storybook/test-runner':
     specifier: ^0.11.0
     version: 0.11.0(@types/node@20.4.5)
@@ -78,10 +78,10 @@ devDependencies:
     version: 7.1.1
   '@sveltejs/package':
     specifier: ^2.2.0
-    version: 2.2.0(svelte@3.55.0)(typescript@5.1.6)
+    version: 2.2.0(svelte@4.0.0)(typescript@5.1.6)
   '@sveltejs/vite-plugin-svelte':
     specifier: ^2.4.2
-    version: 2.4.2(svelte@3.55.0)(vite@4.4.3)
+    version: 2.4.2(svelte@4.0.0)(vite@4.4.3)
   '@tsconfig/svelte':
     specifier: ^5.0.0
     version: 5.0.0
@@ -122,17 +122,17 @@ devDependencies:
     specifier: ^7.1.1
     version: 7.1.1
   svelte:
-    specifier: ^3.55.0
-    version: 3.55.0
+    specifier: ^4.0.0
+    version: 4.0.0
   svelte-check:
     specifier: ^3.5.0
-    version: 3.5.0(@babel/core@7.22.9)(svelte@3.55.0)
+    version: 3.5.0(@babel/core@7.22.9)(svelte@4.0.0)
   svelte-jester:
     specifier: ^2.3.2
-    version: 2.3.2(jest@29.6.2)(svelte@3.55.0)
+    version: 2.3.2(jest@29.6.2)(svelte@4.0.0)
   svelte-loader:
     specifier: ^3.1.7
-    version: 3.1.7(svelte@3.55.0)
+    version: 3.1.7(svelte@4.0.0)
   typescript:
     specifier: ^5.1.6
     version: 5.1.6
@@ -3561,7 +3561,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /@storybook/svelte-vite@7.1.1(svelte@3.55.0)(typescript@5.1.6)(vite@4.4.3):
+  /@storybook/svelte-vite@7.1.1(svelte@4.0.0)(typescript@5.1.6)(vite@4.4.3):
     resolution: {integrity: sha512-0GyqGDUh/szuCyUZ++X93qND5w45mv83pdgtQQZlTImQcW/NZxPWB1i6B5bBxPgSkIXvaOuW8JpjC21YGFGRcg==}
     engines: {node: ^14.18 || >=16}
     peerDependencies:
@@ -3570,10 +3570,10 @@ packages:
     dependencies:
       '@storybook/builder-vite': 7.1.1(typescript@5.1.6)(vite@4.4.3)
       '@storybook/node-logger': 7.1.1
-      '@storybook/svelte': 7.1.1(svelte@3.55.0)
-      '@sveltejs/vite-plugin-svelte': 2.4.2(svelte@3.55.0)(vite@4.4.3)
+      '@storybook/svelte': 7.1.1(svelte@4.0.0)
+      '@sveltejs/vite-plugin-svelte': 2.4.2(svelte@4.0.0)(vite@4.4.3)
       magic-string: 0.30.1
-      svelte: 3.55.0
+      svelte: 4.0.0
       sveltedoc-parser: 4.2.1
       ts-dedent: 2.2.0
       vite: 4.4.3(@types/node@20.4.5)
@@ -3585,7 +3585,7 @@ packages:
       - vite-plugin-glimmerx
     dev: true
 
-  /@storybook/svelte@7.1.1(svelte@3.55.0):
+  /@storybook/svelte@7.1.1(svelte@4.0.0):
     resolution: {integrity: sha512-mQLmJCYGxdHWKVEeKcaB1Y+BapH6vwyPOuQ0W3Fy1Pv0k0+/UO5sxS63ps2HsCjloYndLn8drwtx11HrM/G6zw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -3598,7 +3598,7 @@ packages:
       '@storybook/global': 5.0.0
       '@storybook/preview-api': 7.1.1
       '@storybook/types': 7.1.1
-      svelte: 3.55.0
+      svelte: 4.0.0
       sveltedoc-parser: 4.2.1
       type-fest: 3.13.1
     transitivePeerDependencies:
@@ -3708,7 +3708,7 @@ packages:
       file-system-cache: 2.3.0
     dev: true
 
-  /@sveltejs/package@2.2.0(svelte@3.55.0)(typescript@5.1.6):
+  /@sveltejs/package@2.2.0(svelte@4.0.0)(typescript@5.1.6):
     resolution: {integrity: sha512-TXbrzsk+T5WNcSzrU41D8P32vU5guo96lVS11/R+rpLhZBH5sORh0Qp6r68Jg4O5vcdS3JLwpwcpe8VFbT/QeA==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
@@ -3719,13 +3719,13 @@ packages:
       kleur: 4.1.5
       sade: 1.8.1
       semver: 7.5.4
-      svelte: 3.55.0
-      svelte2tsx: 0.6.19(svelte@3.55.0)(typescript@5.1.6)
+      svelte: 4.0.0
+      svelte2tsx: 0.6.19(svelte@4.0.0)(typescript@5.1.6)
     transitivePeerDependencies:
       - typescript
     dev: true
 
-  /@sveltejs/vite-plugin-svelte-inspector@1.0.3(@sveltejs/vite-plugin-svelte@2.4.2)(svelte@3.55.0)(vite@4.4.3):
+  /@sveltejs/vite-plugin-svelte-inspector@1.0.3(@sveltejs/vite-plugin-svelte@2.4.2)(svelte@4.0.0)(vite@4.4.3):
     resolution: {integrity: sha512-Khdl5jmmPN6SUsVuqSXatKpQTMIifoQPDanaxC84m9JxIibWvSABJyHpyys0Z+1yYrxY5TTEQm+6elh0XCMaOA==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
@@ -3733,28 +3733,28 @@ packages:
       svelte: ^3.54.0 || ^4.0.0
       vite: ^4.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.4.2(svelte@3.55.0)(vite@4.4.3)
+      '@sveltejs/vite-plugin-svelte': 2.4.2(svelte@4.0.0)(vite@4.4.3)
       debug: 4.3.4
-      svelte: 3.55.0
+      svelte: 4.0.0
       vite: 4.4.3(@types/node@20.4.5)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@sveltejs/vite-plugin-svelte@2.4.2(svelte@3.55.0)(vite@4.4.3):
+  /@sveltejs/vite-plugin-svelte@2.4.2(svelte@4.0.0)(vite@4.4.3):
     resolution: {integrity: sha512-ePfcC48ftMKhkT0OFGdOyycYKnnkT6i/buzey+vHRTR/JpQvuPzzhf1PtKqCDQfJRgoPSN2vscXs6gLigx/zGw==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
       svelte: ^3.54.0 || ^4.0.0
       vite: ^4.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 1.0.3(@sveltejs/vite-plugin-svelte@2.4.2)(svelte@3.55.0)(vite@4.4.3)
+      '@sveltejs/vite-plugin-svelte-inspector': 1.0.3(@sveltejs/vite-plugin-svelte@2.4.2)(svelte@4.0.0)(vite@4.4.3)
       debug: 4.3.4
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.1
-      svelte: 3.55.0
-      svelte-hmr: 0.15.2(svelte@3.55.0)
+      svelte: 4.0.0
+      svelte-hmr: 0.15.2(svelte@4.0.0)
       vite: 4.4.3(@types/node@20.4.5)
       vitefu: 0.2.4(vite@4.4.3)
     transitivePeerDependencies:
@@ -5421,6 +5421,16 @@ packages:
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
     dev: true
 
+  /code-red@1.0.4:
+    resolution: {integrity: sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+      '@types/estree': 1.0.1
+      acorn: 8.10.0
+      estree-walker: 3.0.3
+      periscopic: 3.1.0
+    dev: true
+
   /collapse-white-space@1.0.6:
     resolution: {integrity: sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==}
     dev: true
@@ -5649,6 +5659,14 @@ packages:
   /crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
     engines: {node: '>=8'}
+    dev: true
+
+  /css-tree@2.3.1:
+    resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+    dependencies:
+      mdn-data: 2.0.30
+      source-map-js: 1.0.2
     dev: true
 
   /css.escape@1.5.1:
@@ -6821,6 +6839,12 @@ packages:
   /estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+    dev: true
+
+  /estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+    dependencies:
+      '@types/estree': 1.0.1
     dev: true
 
   /esutils@2.0.3:
@@ -8001,6 +8025,12 @@ packages:
 
   /is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+    dev: true
+
+  /is-reference@3.0.1:
+    resolution: {integrity: sha512-baJJdQLiYaJdvFbJqXrcGv3WU3QCzBlUcI5QhbesIm6/xPsvmO+2CDoi/GMOFBQEQm+PXkwOPrp9KK5ozZsp2w==}
+    dependencies:
+      '@types/estree': 1.0.1
     dev: true
 
   /is-regex@1.1.4:
@@ -9363,6 +9393,10 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
+  /locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
+    dev: true
+
   /locate-path@2.0.0:
     resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==}
     engines: {node: '>=4'}
@@ -9583,6 +9617,10 @@ packages:
 
   /mdast-util-to-string@2.0.0:
     resolution: {integrity: sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==}
+    dev: true
+
+  /mdn-data@2.0.30:
+    resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
     dev: true
 
   /meant@1.0.3:
@@ -10296,6 +10334,14 @@ packages:
 
   /pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+    dev: true
+
+  /periscopic@3.1.0:
+    resolution: {integrity: sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==}
+    dependencies:
+      '@types/estree': 1.0.1
+      estree-walker: 3.0.3
+      is-reference: 3.0.1
     dev: true
 
   /picocolors@1.0.0:
@@ -11766,7 +11812,7 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /svelte-check@3.5.0(@babel/core@7.22.9)(svelte@3.55.0):
+  /svelte-check@3.5.0(@babel/core@7.22.9)(svelte@4.0.0):
     resolution: {integrity: sha512-KHujbn4k17xKYLmtCwv0sKKM7uiHTYcQvXnvrCcNU6a7hcszh99zFTIoiu/Sp/ewAw5aJmillJ1Cs8gKLmcX4A==}
     hasBin: true
     peerDependencies:
@@ -11778,8 +11824,8 @@ packages:
       import-fresh: 3.3.0
       picocolors: 1.0.0
       sade: 1.8.1
-      svelte: 3.55.0
-      svelte-preprocess: 5.0.4(@babel/core@7.22.9)(svelte@3.55.0)(typescript@5.1.6)
+      svelte: 4.0.0
+      svelte-preprocess: 5.0.4(@babel/core@7.22.9)(svelte@4.0.0)(typescript@5.1.6)
       typescript: 5.1.6
     transitivePeerDependencies:
       - '@babel/core'
@@ -11797,25 +11843,25 @@ packages:
     resolution: {integrity: sha512-oU+Xv7Dl4kRU2kdFjsoPLfJfnt5hUhsFUZtuzI3Ku/f2iAFZqBoEuXOqK3N9ngD4dxQOmN4OKWPHVi3NeAeAfQ==}
     dev: true
 
-  /svelte-hmr@0.14.12(svelte@3.55.0):
+  /svelte-hmr@0.14.12(svelte@4.0.0):
     resolution: {integrity: sha512-4QSW/VvXuqVcFZ+RhxiR8/newmwOCTlbYIezvkeN6302YFRE8cXy0naamHcjz8Y9Ce3ITTZtrHrIL0AGfyo61w==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
       svelte: '>=3.19.0'
     dependencies:
-      svelte: 3.55.0
+      svelte: 4.0.0
     dev: true
 
-  /svelte-hmr@0.15.2(svelte@3.55.0):
+  /svelte-hmr@0.15.2(svelte@4.0.0):
     resolution: {integrity: sha512-q/bAruCvFLwvNbeE1x3n37TYFb3mTBJ6TrCq6p2CoFbSTNhDE9oAtEfpy+wmc9So8AG0Tja+X0/mJzX9tSfvIg==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
       svelte: ^3.19.0 || ^4.0.0-next.0
     dependencies:
-      svelte: 3.55.0
+      svelte: 4.0.0
     dev: true
 
-  /svelte-jester@2.3.2(jest@29.6.2)(svelte@3.55.0):
+  /svelte-jester@2.3.2(jest@29.6.2)(svelte@4.0.0):
     resolution: {integrity: sha512-JtxSz4FWAaCRBXbPsh4LcDs4Ua7zdXgLC0TZvT1R56hRV0dymmNP+abw67DTPF7sQPyNxWsOKd0Sl7Q8SnP8kg==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -11823,21 +11869,21 @@ packages:
       svelte: '>= 3'
     dependencies:
       jest: 29.6.2(@types/node@20.4.5)
-      svelte: 3.55.0
+      svelte: 4.0.0
     dev: true
 
-  /svelte-loader@3.1.7(svelte@3.55.0):
+  /svelte-loader@3.1.7(svelte@4.0.0):
     resolution: {integrity: sha512-YVg5gQaUdV26uaA5SEGj1VOUX0YQicD9PezKvVlkQ2JI644silWtJZ3hkxHtXSfjnlFr0OTNoyOgeINIODdT+A==}
     peerDependencies:
       svelte: '>3.0.0'
     dependencies:
       loader-utils: 2.0.4
-      svelte: 3.55.0
+      svelte: 4.0.0
       svelte-dev-helper: 1.1.9
-      svelte-hmr: 0.14.12(svelte@3.55.0)
+      svelte-hmr: 0.14.12(svelte@4.0.0)
     dev: true
 
-  /svelte-preprocess@5.0.4(@babel/core@7.22.9)(svelte@3.55.0)(typescript@5.1.6):
+  /svelte-preprocess@5.0.4(@babel/core@7.22.9)(svelte@4.0.0)(typescript@5.1.6):
     resolution: {integrity: sha512-ABia2QegosxOGsVlsSBJvoWeXy1wUKSfF7SWJdTjLAbx/Y3SrVevvvbFNQqrSJw89+lNSsM58SipmZJ5SRi5iw==}
     engines: {node: '>= 14.10.0'}
     requiresBuild: true
@@ -11881,11 +11927,11 @@ packages:
       magic-string: 0.27.0
       sorcery: 0.11.0
       strip-indent: 3.0.0
-      svelte: 3.55.0
+      svelte: 4.0.0
       typescript: 5.1.6
     dev: true
 
-  /svelte2tsx@0.6.19(svelte@3.55.0)(typescript@5.1.6):
+  /svelte2tsx@0.6.19(svelte@4.0.0)(typescript@5.1.6):
     resolution: {integrity: sha512-h3b5OtcO8zyVL/RiB2zsDwCopeo/UH+887uyhgb2mjnewOFwiTxu+4IGuVwrrlyuh2onM2ktfUemNrNmQwXONQ==}
     peerDependencies:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0
@@ -11893,13 +11939,27 @@ packages:
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
-      svelte: 3.55.0
+      svelte: 4.0.0
       typescript: 5.1.6
     dev: true
 
-  /svelte@3.55.0:
-    resolution: {integrity: sha512-uGu2FVMlOuey4JoKHKrpZFkoYyj0VLjJdz47zX5+gVK5odxHM40RVhar9/iK2YFRVxvfg9FkhfVlR0sjeIrOiA==}
-    engines: {node: '>= 8'}
+  /svelte@4.0.0:
+    resolution: {integrity: sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@ampproject/remapping': 2.2.1
+      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/trace-mapping': 0.3.18
+      acorn: 8.10.0
+      aria-query: 5.3.0
+      axobject-query: 3.2.1
+      code-red: 1.0.4
+      css-tree: 2.3.1
+      estree-walker: 3.0.3
+      is-reference: 3.0.1
+      locate-character: 3.0.0
+      magic-string: 0.30.1
+      periscopic: 3.1.0
     dev: true
 
   /sveltedoc-parser@4.2.1:

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-import type { SvelteComponentTyped, SvelteComponent } from 'svelte';
+import type { SvelteComponent } from 'svelte'
 import type { Addon_BaseMeta as BaseMeta, Addon_BaseAnnotations as BaseAnnotations, StoryContext, WebRenderer } from '@storybook/types';
 
 
@@ -54,14 +54,14 @@ interface Slots {
 /**
  * Meta.
  */
-export class Meta extends SvelteComponentTyped<BaseMeta<any> & BaseAnnotations<any, DecoratorReturnType>> { }
+export class Meta extends SvelteComponent<BaseMeta<any> & BaseAnnotations<any, DecoratorReturnType>> { }
 /**
  * Story.
  */
-export class Story extends SvelteComponentTyped<StoryProps, any, Slots> { }
+export class Story extends SvelteComponent<StoryProps, any, Slots> { }
 /**
  * Template.
  * 
  * Allow to reuse definition between stories.
  */
-export class Template extends SvelteComponentTyped<TemplateProps, any, Slots> { }
+export class Template extends SvelteComponent<TemplateProps, any, Slots> { }


### PR DESCRIPTION
Works on https://github.com/storybookjs/addon-svelte-csf/issues/121#issuecomment-1686214199

cc @RSWilli 

This PR upgrades the required peer dependencies:

- `@sveltejs/vite-plugin-svelte`: `^2.0.0`
- `svelte`: `^4.0.0`
- `vite`: `^4.0.0`

And recreates the typing changes introduced in #112 to support Svelte v4.

Telescopes on top of #127 to release a new major version. **Don't merge until that has been merged and released.**

@benmccann I figured I'd use this breaking opportunity to upgrade Vite and the Vite plugin, do you see any issue in that? Are the older versions still used a lot for some reason?

I've tested that this still works with types by installing this canary in a Svelte v3 project and see that it fails, and then upgrading to Svelte v4 and see that it works.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.0.0--canary.128.b77ea51.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-svelte-csf@4.0.0--canary.128.b77ea51.0
  # or 
  yarn add @storybook/addon-svelte-csf@4.0.0--canary.128.b77ea51.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
