### PR TITLE
Supports for tags in <Meta/>

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,23 @@ It supports:
 ## Example
 
 ```svelte
-<script>
-  import { Meta, Story, Template } from '@storybook/addon-svelte-csf';
-
+<script content="module">
   import Button from './Button.svelte';
+
+  export const meta = {
+    title: "Button",
+    component: Button
+  }
+</script>
+
+<script>
+  import { Story, Template } from '@storybook/addon-svelte-csf';
 
   let count = 0;
   function handleClick() {
     count += 1;
   }
 </script>
-
-<Meta title="Button" component={Button}/>
 
 <Template let:args>
   <Button {...args} on:click={handleClick}>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -44,7 +44,23 @@ interface TemplateProps extends BaseAnnotations<any, DecoratorReturnType> {
     id?: string;
 }
 
-interface MetaProps extends BaseMeta<any>, BaseAnnotations<any, DecoratorReturnType> { }
+interface MetaProps extends BaseMeta<any>, BaseAnnotations<any, DecoratorReturnType> {
+    /**
+     * Enable the tag 'autodocs'.
+     * 
+     * @see [Automatic documentation](https://storybook.js.org/docs/svelte/writing-docs/autodocs)
+     */
+    autodocs?: boolean;
+    /**
+     * List of tags to add to the stories.
+     * 
+     * It should be a static array of strings.
+     * 
+     * @example
+     *   tags={['autodocs']}
+     */
+    tags?: string[];
+}
 
 interface Slots {
     default: {
@@ -55,6 +71,8 @@ interface Slots {
 }
 /**
  * Meta.
+ * 
+ * @deprecated See https://github.com/storybookjs/addon-svelte-csf/issues/135
  */
 export class Meta extends SvelteComponent<MetaProps> { }
 /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -56,8 +56,7 @@ interface MetaProps extends BaseMeta<any>, BaseAnnotations<any, DecoratorReturnT
      * 
      * It should be a static array of strings.
      * 
-     * @example
-     *   tags={['autodocs']}
+     * @example tags={['autodocs']}
      */
     tags?: string[];
 }
@@ -72,7 +71,7 @@ interface Slots {
 /**
  * Meta.
  * 
- * @deprecated See https://github.com/storybookjs/addon-svelte-csf/issues/135
+ * @deprecated Use `export const meta`. See https://github.com/storybookjs/addon-svelte-csf for an example
  */
 export class Meta extends SvelteComponent<MetaProps> { }
 /**

--- a/src/parser/collect-stories.ts
+++ b/src/parser/collect-stories.ts
@@ -35,7 +35,7 @@ const createFragment = document.createDocumentFragment
   ? () => document.createDocumentFragment()
   : () => document.createElement('div');
 
-export default (StoriesComponent, { stories = {}, allocatedIds = [] }) => {
+export default (StoriesComponent, { stories = {}, allocatedIds = [] }, exportedMeta = undefined) => {
   const repositories = {
     meta: null as Meta | null,
     stories: [] as Story[],
@@ -55,7 +55,7 @@ export default (StoriesComponent, { stories = {}, allocatedIds = [] }) => {
     logger.error(`Error extracting stories ${e.toString()}`, e);
   }
 
-  const { meta } = repositories;
+  const meta = exportedMeta || repositories.meta;
   if (!meta) {
     logger.error('Missing <Meta/> tag');
     return {};

--- a/src/parser/extract-stories.test.ts
+++ b/src/parser/extract-stories.test.ts
@@ -221,6 +221,124 @@ describe('extractSource', () => {
       }
     `);
   });
+  test('Add tags autodocs', () => {
+    expect(
+      extractStories(`
+        <script>
+          import { Story, Meta } from '@storybook/addon-svelte-csf';
+        </script>
+
+        <Meta title='test' autodocs/>
+
+        <Story name="Story1">
+          <div>story 1</div>
+        </Story>
+        `)
+    ).toMatchInlineSnapshot(`
+      {
+        "allocatedIds": [
+          "default",
+          "Story",
+          "Meta",
+        ],
+        "meta": {
+          "id": undefined,
+          "tags": [
+            "autodocs",
+          ],
+          "title": "test",
+        },
+        "stories": {
+          "Story1": {
+            "hasArgs": false,
+            "name": "Story1",
+            "source": "<div>story 1</div>",
+            "storyId": "test--story-1",
+            "template": false,
+          },
+        },
+      }
+    `);
+  });
+  test('Add tags', () => {
+    expect(
+      extractStories(`
+        <script>
+          import { Story, Meta } from '@storybook/addon-svelte-csf';
+        </script>
+
+        <Meta title='test' tags={['a','b']}/>
+
+        <Story name="Story1">
+          <div>story 1</div>
+        </Story>
+        `)
+    ).toMatchInlineSnapshot(`
+      {
+        "allocatedIds": [
+          "default",
+          "Story",
+          "Meta",
+        ],
+        "meta": {
+          "id": undefined,
+          "tags": [
+            "a",
+            "b",
+          ],
+          "title": "test",
+        },
+        "stories": {
+          "Story1": {
+            "hasArgs": false,
+            "name": "Story1",
+            "source": "<div>story 1</div>",
+            "storyId": "test--story-1",
+            "template": false,
+          },
+        },
+      }
+    `);
+  });
+  test('Add Only one tag', () => {
+    expect(
+      extractStories(`
+        <script>
+          import { Story, Meta } from '@storybook/addon-svelte-csf';
+        </script>
+
+        <Meta title='test' tags='a'/>
+
+        <Story name="Story1">
+          <div>story 1</div>
+        </Story>
+        `)
+    ).toMatchInlineSnapshot(`
+      {
+        "allocatedIds": [
+          "default",
+          "Story",
+          "Meta",
+        ],
+        "meta": {
+          "id": undefined,
+          "tags": [
+            "a",
+          ],
+          "title": "test",
+        },
+        "stories": {
+          "Story1": {
+            "hasArgs": false,
+            "name": "Story1",
+            "source": "<div>story 1</div>",
+            "storyId": "test--story-1",
+            "template": false,
+          },
+        },
+      }
+    `);
+  });
   test('Duplicate Id', () => {
     expect(
       extractStories(`

--- a/src/parser/extract-stories.test.ts
+++ b/src/parser/extract-stories.test.ts
@@ -339,6 +339,32 @@ describe('extractSource', () => {
       }
     `);
   });
+  test('Meta as exported module object', () => {
+    expect(
+      extractStories(`
+        <script context='module'>
+          export const meta = {
+            title: 'MyStory',
+            tags: ['a']
+          };
+        </script>
+        `)
+    ).toMatchInlineSnapshot(`
+      {
+        "allocatedIds": [
+          "default",
+        ],
+        "meta": {
+          "id": undefined,
+          "tags": [
+            "a",
+          ],
+          "title": "MyStory",
+        },
+        "stories": {},
+      }
+    `);
+  });
   test('Duplicate Id', () => {
     expect(
       extractStories(`

--- a/src/parser/extract-stories.ts
+++ b/src/parser/extract-stories.ts
@@ -238,7 +238,6 @@ export function extractStories(component: string): StoriesDef {
       }
     },
   });
-  
   return {
     meta,
     stories,

--- a/src/parser/svelte-stories-loader.ts
+++ b/src/parser/svelte-stories-loader.ts
@@ -54,11 +54,12 @@ function transformSvelteStories(code: string) {
     .map(([id]) => `export const ${id} = __storiesMetaData.stories[${JSON.stringify(id)}]`)
     .join('\n');
 
-  const codeWithoutDefaultExport = code.replace('export default ', '//export default');
-
+  const metaExported = code.includes('export { meta }');
+  const codeWithoutDefaultExport = code.replace('export default ', '//export default').replace('export { meta };', '// export { meta };');
+  
   return `${codeWithoutDefaultExport}
     const { default: parser } = require('${parser}');
-    const __storiesMetaData = parser(${componentName}, ${JSON.stringify(storiesDef)});
+    const __storiesMetaData = parser(${componentName}, ${JSON.stringify(storiesDef)}${metaExported ? ', meta' : ''});
     export default __storiesMetaData.meta;
     ${storyDef};
   ` as string;

--- a/src/plugins/vite-svelte-csf.ts
+++ b/src/plugins/vite-svelte-csf.ts
@@ -42,10 +42,12 @@ export default function csfPlugin(svelteOptions) {
         .filter(([, def]) => !def.template)
         .map(([storyId]) => storyId);
 
+      const metaExported = code.includes('export { meta }');
+      s.replace('export { meta };', '// export { meta };');
       const output = [
         '',
         `import parser from '${parser}';`,
-        `const __storiesMetaData = parser(${component}, ${JSON.stringify(all)});`,
+        `const __storiesMetaData = parser(${component}, ${JSON.stringify(all)}${metaExported ? ', meta' : ''});`,
         'export default __storiesMetaData.meta;',
         `export const __namedExportsOrder = ${JSON.stringify(namedExportsOrder)};`,
         storyDef,

--- a/stories/metaexport.stories.svelte
+++ b/stories/metaexport.stories.svelte
@@ -1,0 +1,35 @@
+<script context='module'>
+  import Button from './Button.svelte';
+
+  export const meta = {
+    title: 'MetaExport',
+    component: Button,
+    tags: ['autodocs']
+  }
+</script>
+
+<script>
+  import { Story, Template } from '../src/index';
+
+  let count = 0;
+  function handleClick() {
+    count += 1;
+  }
+</script>
+
+<Template let:args>
+  <Button {...args} on:click={handleClick}>
+    You clicked: {count}
+  </Button>
+</Template>
+
+<Story name="Default"/>
+
+<Story name="Rounded" args={{rounded: true}}/>
+
+<Story name="Square" source args={{rounded: false}}/>
+
+<!-- Dynamic snippet should be disabled for this story -->
+<Story name="Button No Args">
+  <Button>Label</Button>
+</Story>


### PR DESCRIPTION
Storybook v7 supports tag on the meta property. However, tags should be set on the story indexer to be seen by the autodocs feature. The only tag used today by storybook is `autodocs`AFAIK.

This PR add supports for tags and an alias to a 'autodocs' property. Tags can only be specified as a static property, because it should be build by parsing the AST.

Examples:

```
<Meta title="XX" autodocs/>
````

```
<Meta title="XX" tags="autodocs"/>
```

```
<Meta title="XX" tags={['autodocs', 'a', 'b']}/>
```

