### PR TITLE
fix: move MetaProps to its own declaration to allow for overrides

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -44,7 +44,7 @@ interface TemplateProps extends BaseAnnotations<any, DecoratorReturnType> {
     id?: string;
 }
 
-interface MetaProps extends BaseMeta<any> extends BaseAnnotations<any, DecoratorReturnType> { }
+interface MetaProps extends (BaseMeta<any> & BaseAnnotations<any, DecoratorReturnType>) { }
 
 interface Slots {
     default: {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -44,6 +44,8 @@ interface TemplateProps extends BaseAnnotations<any, DecoratorReturnType> {
     id?: string;
 }
 
+interface MetaProps extends BaseMeta<any> extends BaseAnnotations<any, DecoratorReturnType> { }
+
 interface Slots {
     default: {
         args: any;
@@ -54,7 +56,7 @@ interface Slots {
 /**
  * Meta.
  */
-export class Meta extends SvelteComponent<BaseMeta<any> & BaseAnnotations<any, DecoratorReturnType>> { }
+export class Meta extends SvelteComponent<MetaProps> { }
 /**
  * Story.
  */


### PR DESCRIPTION
Right now the Meta class doesn't have a Props interface. This make it impossible to add overrides to the props (i'm using interface merging to provide intellisense for some parameters)

With this simple change the users will be able to augment the the typing of the Meta component