### PR TITLE
Export typed Story and Template components

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponent, ComponentType } from 'svelte'
 import type { Addon_BaseMeta as BaseMeta, Addon_BaseAnnotations as BaseAnnotations, StoryContext, WebRenderer } from '@storybook/types';
-
+import type { Meta } from '@storybook/svelte';
 
 type DecoratorReturnType = void | SvelteComponent | {
     Component: any,
@@ -44,7 +44,7 @@ interface TemplateProps<Props = any> extends BaseAnnotations<Props, DecoratorRet
     id?: string;
 }
 
-interface MetaProps extends BaseMeta<any>, BaseAnnotations<any, DecoratorReturnType> {
+interface MetaProps extends BaseMeta<any>, BaseAnnotations<Props, DecoratorReturnType> {
     /**
      * Enable the tag 'autodocs'.
      * 
@@ -94,10 +94,14 @@ export interface StoriesComponents<Props = any> {
  * 
  * @exemple
  * ```
- * <script context="meta">
- *   import { makeFrom } from "@storybook/addon-svelte-csf";
+ * <script context="module">
+ *   import { typed } from "@storybook/addon-svelte-csf";
  *   import Button from "./Button.svelte";
- *   const { Template, Story } = makeFrom(Button);
+ * 
+ *   export const meta = {
+ *     component: Button
+ *   }
+ *   const { Template, Story } = typed(meta); // or typed(Button)
  * </script>
  * 
  * <Template let:args>
@@ -111,5 +115,5 @@ export interface StoriesComponents<Props = any> {
  * 
  * @param component Component
  */
-export function makeFrom<C extends SvelteComponent>(component?: ComponentType<C>): 
-    C extends SvelteComponent<infer Props> ? StoriesComponents<Props> : never;
+export function typed<C>(meta?: C): 
+    C extends Meta<infer Args> ? StoriesComponents<Args> : C extends ComponentType<SvelteComponent<infer Props>> ? StoriesComponents<Props> : never;

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import Template from './components/Template.svelte';
 
 export { Story, Template };
 
-export function makeFrom() {
+export function typed() {
   return { Story, Template };
 }
 if (module?.hot?.decline) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,12 @@
 export { default as Meta } from './components/Meta.svelte';
-export { default as Story } from './components/Story.svelte';
-export { default as Template } from './components/Template.svelte';
+import Story from './components/Story.svelte';
+import Template from './components/Template.svelte';
 
+export { Story, Template };
+
+export function makeFrom() {
+  return { Story, Template };
+}
 if (module?.hot?.decline) {
   module.hot.decline();
 }

--- a/stories/button.stories.svelte
+++ b/stories/button.stories.svelte
@@ -1,12 +1,14 @@
 <script>
-  import { Meta, Story, Template } from '../src/index';
-
+  import { Meta, makeFrom } from '../src/index.js';
   import Button from './Button.svelte';
 
   let count = 0;
   function handleClick() {
     count += 1;
   }
+
+  const { Story, Template } = makeFrom(Button)
+
 </script>
 
 <Meta component={Button}/>

--- a/stories/button.stories.svelte
+++ b/stories/button.stories.svelte
@@ -1,5 +1,5 @@
-<script>
-  import { Meta, makeFrom } from '../src/index.js';
+<script context="module">
+  import { typed } from '../src/index.js';
   import Button from './Button.svelte';
 
   let count = 0;
@@ -7,13 +7,15 @@
     count += 1;
   }
 
-  const { Story, Template } = makeFrom(Button)
+  export const meta = {
+    component: Button,
+  };
+
+  const { Story, Template } = typed(meta);
 
 </script>
 
-<Meta component={Button}/>
-
-<Template let:args>
+<Template let:args let:text>
   <Button {...args} on:click={handleClick} on:click>
     You clicked: {count}
   </Button>
@@ -21,7 +23,7 @@
 
 <Story name="Default"/>
 
-<Story name="Rounded" args={{rounded: true}}/>
+<Story name="Rounded" args={{ rounded: true }}/>
 
 <Story name="Square" source args={{rounded: false}}/>
 


### PR DESCRIPTION
Should implements #152 

I`m not sure about the syntax however, but it works in vscode (invalid args or use of args are flagged as errors)

```svelte
<script context="meta">
  import { makeFrom } from "@storybook/addon-svelte-csf";
  import Button from "./Button.svelte";
  const { Template, Story } = makeFrom(Button);

  export const meta = {
    component: Button
  }
</script>
 
<Template let:args>
  <!- args is typed here -->
   <Button {...args}/>
</Template>
 
<!-- args is type checked here -->
<Story args={{rounded: false}}/>
```

