### PR TITLE
Exports package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "./manager": {
       "types": "./dist/preset/manager.d.ts",
       "default": "./dist/preset/manager.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist/**/*",


### PR DESCRIPTION
This adds an entry in `package.json` to export `package.json`.

**Why?**

I'm using `addon-svelte-csf` in a monorepo where I need to find the absolute path of a package in `.storybook/main.js`. A simplified version:

```javascript
addons: [
  dirname(require.resolve(join('@storybook/addon-svelte-csf', 'package.json')))
]
```

**What happens currently?**

Without the exported `package.json`, we hit an error attempting to get it

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package.json' is not defined by "exports"
```

**Is this normal?**

I *think* so. Looking at other official addons, it looks common to export `package.json`. Examples:

- controls https://github.com/storybookjs/storybook/blob/next/code/addons/controls/package.json#L37
- addon-links https://github.com/storybookjs/storybook/blob/next/code/addons/links/package.json#L39C5-L39C39
- a11y https://github.com/storybookjs/storybook/blob/next/code/addons/a11y/package.json#L38

Again, this seems OK to do, but I am a little hazy on how the `exports` setup is supposed to work, so this may not be the right way to do this.