### PR TITLE
Add component description from jsdoc on meta export

### DIFF
--- a/src/parser/extract-stories.test.ts
+++ b/src/parser/extract-stories.test.ts
@@ -362,6 +362,36 @@ describe('extractSource', () => {
       }
     `);
   });
+  test('Meta Description', () => {
+    expect(
+      extractStories(`
+        <script context='module'>
+          /**
+           * A description of meta
+           */ 
+          export const meta = {
+            title: 'MyStory',
+            tags: ['a']
+          };
+        </script>
+        `)
+    ).toMatchInlineSnapshot(`
+      {
+        "allocatedIds": [
+          "default",
+        ],
+        "meta": {
+          "description": "A description of meta",
+          "id": undefined,
+          "tags": [
+            "a",
+          ],
+          "title": "MyStory",
+        },
+        "stories": {},
+      }
+    `);
+  });
   test('Duplicate Id', () => {
     expect(
       extractStories(`
@@ -390,6 +420,33 @@ describe('extractSource', () => {
             "template": false,
           },
         },
+      }
+    `);
+  });
+  test('Meta tag description', () => {
+    expect(
+      extractStories(`
+        <script>
+          import { Story } from '@storybook/svelte';
+          import Button from './Button.svelte';
+        </script>
+
+        <!-- Meta Description -->
+        <Meta title="a title"/>
+        `)
+    ).toMatchInlineSnapshot(`
+      {
+        "allocatedIds": [
+          "default",
+          "Story",
+          "Button",
+        ],
+        "meta": {
+          "description": "Meta Description",
+          "id": undefined,
+          "title": "a title",
+        },
+        "stories": {},
       }
     `);
   });

--- a/src/parser/extract-stories.ts
+++ b/src/parser/extract-stories.ts
@@ -3,26 +3,7 @@ import type { Node } from 'estree';
 
 import dedent from 'dedent';
 import { extractId } from './extract-id.js';
-
-export interface StoryDef {
-  name: string;
-  template: boolean;
-  source: string;
-  description?: string;
-  hasArgs: boolean;
-}
-
-interface MetaDef {
-  title?: string;
-  id?: string;
-  tags?: string[];
-}
-
-interface StoriesDef {
-  meta: MetaDef;
-  stories: Record<string, StoryDef>;
-  allocatedIds: string[];
-}
+import type { MetaDef, StoriesDef, StoryDef } from './types.js';
 
 function lookupAttribute(name: string, attributes: any[]) {
   return attributes.find((att: any) => 
@@ -184,6 +165,11 @@ export function extractStories(component: string): StoriesDef {
             }
 
             fillMetaFromAttributes(meta, init.properties);
+            if (node.leadingComments?.length > 0) {
+              // throws dedent expression is not callable.
+              // @ts-ignore
+              meta.description = dedent(node.leadingComments[0].value.replaceAll(/^ *\*/mg, ""));
+            }
         }
       }
     });
@@ -244,6 +230,9 @@ export function extractStories(component: string): StoriesDef {
         this.skip();
 
         fillMetaFromAttributes(meta, node.attributes);
+        if (latestComment) {
+          meta.description = latestComment;
+        }
         latestComment = undefined;
       } else if (node.type === 'Comment') {
         this.skip();

--- a/src/parser/types.d.ts
+++ b/src/parser/types.d.ts
@@ -1,0 +1,53 @@
+/**
+ * Story extracted from static analysis.
+ */
+export interface StoryDef {
+  name: string;
+  template: boolean;
+  source: string;
+  description?: string;
+  hasArgs: boolean;
+}
+
+/**
+ * Meta extracted from static analysis.
+ */
+export interface MetaDef {
+  title?: string;
+  id?: string;
+  tags?: string[];
+  description?: string;
+}
+
+/**
+ * Informations extracted from static analysis.
+ */
+export interface StoriesDef {
+  meta: MetaDef;
+  stories: Record<string, StoryDef>;
+  /**
+   * All allocated ids in the svelte script section.
+   */
+  allocatedIds: string[];
+}
+
+/**
+ * Story extracted from executing the Stories component.
+ */
+export interface Story {
+  id: string;
+  name: string;
+  template: string;
+  component: any;
+  isTemplate: boolean;
+  source: boolean;
+}
+
+/**
+ * Meta extracted from executing the Stories component.
+ */
+export interface Meta {
+  name: string;
+  component: any;
+  parameters: any;
+}

--- a/src/preset/index.ts
+++ b/src/preset/index.ts
@@ -1,6 +1,5 @@
 import { fileURLToPath } from 'url';
 import { svelteIndexer, createIndex } from './indexer.js';
-import { create } from '@storybook/theming';
 
 export function managerEntries(entry = []) {
   return [

--- a/stories/button.stories.svelte
+++ b/stories/button.stories.svelte
@@ -9,7 +9,8 @@
   }
 </script>
 
-<Meta component={Button}/>
+<!-- Stories about a Button -->
+<Meta component={Button} autodocs/>
 
 <Template let:args>
   <Button {...args} on:click={handleClick} on:click>

--- a/stories/metaexport_override_descr.stories.svelte
+++ b/stories/metaexport_override_descr.stories.svelte
@@ -2,14 +2,19 @@
   import Button from './Button.svelte';
 
   /**
-   * Stories about a Button.
-   * 
-   * This description is set as a commentary on the meta export.
+   * This commentary should be ignored.
    */
   export const meta = {
-    title: 'MetaExport/MetaExport',
+    title: 'MetaExport/Override',
     component: Button,
-    tags: ['autodocs']
+    tags: ['autodocs'],
+    parameters: {
+      docs: {
+        description: {
+          component: "Description set explicitly in the meta export"
+        }
+      }
+    }
   }
 </script>
 

--- a/stories/metaexport_without_descr.stories.svelte
+++ b/stories/metaexport_without_descr.stories.svelte
@@ -1,13 +1,8 @@
 <script context='module'>
   import Button from './Button.svelte';
 
-  /**
-   * Stories about a Button.
-   * 
-   * This description is set as a commentary on the meta export.
-   */
   export const meta = {
-    title: 'MetaExport/MetaExport',
+    title: 'MetaExport/WithoutDescr',
     component: Button,
     tags: ['autodocs']
   }


### PR DESCRIPTION
Add component description with:

```svelte
<script context="module">
  /**
   * Component description
   */
  export const meta = {
    ...
  }
</script>
```