### PR TITLE
Update versions of peer dependencies to allow latest Vite and Vite Svelte plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "svelte": "^4.0.0",
     "svelte-loader": "^3.1.2",
-    "vite": "^5.0.0"
+    "vite": "^4.0.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {
     "@sveltejs/vite-plugin-svelte": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   "peerDependencies": {
     "@storybook/svelte": "^7.0.0",
     "@storybook/theming": "^7.0.0",
-    "@sveltejs/vite-plugin-svelte": "^3.0.0",
+    "@sveltejs/vite-plugin-svelte": "^2.0.0 || ^3.0.0",
     "svelte": "^4.0.0",
     "svelte-loader": "^3.1.2",
     "vite": "^4.0.0 || ^5.0.0"

--- a/package.json
+++ b/package.json
@@ -100,10 +100,10 @@
   "peerDependencies": {
     "@storybook/svelte": "^7.0.0",
     "@storybook/theming": "^7.0.0",
-    "@sveltejs/vite-plugin-svelte": "^2.0.0",
+    "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "svelte": "^4.0.0",
     "svelte-loader": "^3.1.2",
-    "vite": "^4.0.0"
+    "vite": "^5.0.0"
   },
   "peerDependenciesMeta": {
     "@sveltejs/vite-plugin-svelte": {


### PR DESCRIPTION
Fixes https://github.com/storybookjs/addon-svelte-csf/issues/161

Now that [Vite 5 has been released](https://vitejs.dev/blog/announcing-vite5), it would be nice to have te versions of the peer dependencies for it and the Svelte Vite plugin which uses Vite, updated to the latest versions. If this could be published as a new release that would most awesome!