### PR TITLE
fix: keep track of arguments from a separate map to have the last instance of the component

### DIFF
--- a/src/components/context.ts
+++ b/src/components/context.ts
@@ -6,10 +6,18 @@ import { writable } from 'svelte/store';
 const CONTEXT_KEY = 'storybook-registration-context';
 const CONTEXT_KEY_COMPONENT = 'storybook-registration-context-component';
 
+// this is used to keep track of the arguments of the stories at render time
+export const storyArguments = new Map<string, unknown>();
+
 export function createRenderContext(props: any = {}) {
   setContext(CONTEXT_KEY, {
     render: true,
-    register: () => {},
+    register: (props) => {
+      // when the story is rendered the new props are set to allow
+      // for functions to be in the scope of the correct instance of
+      // the component
+      storyArguments.set(props.name, props);
+    },
     meta: {},
     args: {},
     ...props,

--- a/stories/interaction.stories.svelte
+++ b/stories/interaction.stories.svelte
@@ -4,6 +4,7 @@
   import { userEvent, within } from '@storybook/testing-library';
 
   import Counter from './Counter.svelte';
+  import { tick } from 'svelte';
 
   async function play({ canvasElement }) {
     const canvas = within(canvasElement);
@@ -12,10 +13,26 @@
     const count = await canvas.findByTestId('count');
     expect(count.textContent).toEqual('You clicked 1 times');
   }
+
+  let i = 0;
 </script>
 
 <Meta title="Interactions" component={Counter} />
 
 <Story name="Play" {play}>
   <Counter />
+</Story>
+
+<Story
+  name="Play (capturing scope)"
+  play={async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const p = canvas.getByTestId('count');
+    expect(p.textContent).toEqual('0');
+    i++;
+    await tick();
+    expect(p.textContent).toEqual('1');
+  }}
+>
+  <p data-testid="count">{i}</p>
 </Story>


### PR DESCRIPTION
**THE PROBLEM**

At the end of the day storybook expects a CSF which is structured something like this

```ts
export default {
// meta
}

export const StoryOne = {
// storyone args
}

export const StoryTwo = {
// storytwo args
}
```

to achieve this the vite plugin transform the `.stories.svelte` component and make use of the `parse` function from `collect-stories.ts` that instantiate a "headless" version of the component to collect this information (very clever trick btw).

The problem with this approach however is that if there are closures in those parameters the scope over which they close is the one from the headless story and not the one actually rendered. This means that if you try to modify state from within the `play` function it will not be reflected in the actual mounted story. This is especially annoying if you have to use timing functions (`setInterval` or `setTimeout`) because they need to be cleaned up but the `onDestroy` from svelte doesn't have access to the same scope of the `play` function

Eg.

```svelte
<script>
  let timeout;

  onDestroy(()=>{
    clearTimeout(timeout); // timeout is always undefined
  });
</script>

<Story play={()=>{
  timeout = setTimeout(()=>{}, 1000);
}}>
<Button />
</Story>
```

**THE SOLUTION**

To fix this issue i made two small changes: i created a map of stories_name => stories arguments inside the context and when a `Story` is rendered it update this map. This Map is then imported from `collect-stories.ts` and, if the argument is a function, the actual argument will get the actual argument from the map and call it (passing over every prop). This will ensure that the function will always be the one of the latest render of the story.

I don't know if this is the right approach and i would love some feedback on it from someone with more experience on this addon.