### PR TITLE
chore: Remove `fs-extra` in favor of `node:fs`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.svelte-kit/
 dist/
 node_modules/
 storybook-static/

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@storybook/test": "^8.0.0-rc.2",
     "@storybook/theming": "^8.0.0-rc.2",
     "@storybook/types": "^8.0.0-rc.2",
+    "@sveltejs/kit": "^2.5.7",
     "@sveltejs/package": "^2.2.0",
     "@sveltejs/vite-plugin-svelte": "^2.4.2",
     "@tsconfig/svelte": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   "dependencies": {
     "@babel/runtime": "^7.22.6",
     "dedent": "^1.2.0",
-    "fs-extra": "^11.1.1",
     "magic-string": "^0.30.1"
   },
   "devDependencies": {

--- a/src/preset/indexer.ts
+++ b/src/preset/indexer.ts
@@ -1,10 +1,11 @@
+import fs from 'node:fs/promises';
+
+import { storyNameFromExport, toId } from '@storybook/csf';
+import type { IndexInput, IndexedCSFFile, IndexerOptions } from '@storybook/types';
 import * as svelte from 'svelte/compiler';
 
 import { extractStories } from '../parser/extract-stories.js';
-import fs from 'fs-extra';
 import { loadSvelteConfig } from '../config-loader.js';
-import { storyNameFromExport, toId } from '@storybook/csf';
-import type { IndexInput, IndexedCSFFile, IndexerOptions } from '@storybook/types';
 
 export async function readStories(fileName: string) {
   let code = (await fs.readFile(fileName, 'utf-8')).toString();


### PR DESCRIPTION
I couldn't resist, so I experimented a lot with this addon in order to support Svelte `v5`.
I've refactored the parser locally, to fix the issues I've encountered.

In order to avoid the "big" PR... I'd like to split into smaller PR's, so there's no overhead in the future code review 😅

## What else is done?

- ~~Added `@sveltejs/kit` as dev dependency just for it's type `Config`~~ used updated `@sveltejs/vite-plugin-svelte` which provides a type `SvelteConfig` - fits the project better
- Removed unused dependencies
- Updated dependencies:
  - `@storybook/*` got defaulted to `^8.0.0` version, instead of `rc`
  - `@sveltejs/vite-plugin-svelte` to `^3.0.0`
  - `vite` to `5.0.0`
- Added `.svelte-kit/` to ignore list