### PR TITLE
Replace lodash usage with es-toolkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "dedent": "^1.5.3",
     "es-toolkit": "^1.13.1",
     "esrap": "^1.2.2",
-    "lodash-es": "^4.17.21",
     "magic-string": "^0.30.10",
     "svelte-ast-print": "0.2.3",
     "zimmerframe": "^1.1.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       esrap:
         specifier: ^1.2.2
         version: 1.2.2
-      lodash-es:
-        specifier: ^4.17.21
-        version: 4.17.21
       magic-string:
         specifier: ^0.30.10
         version: 0.30.10
@@ -3970,9 +3967,6 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
-
-  lodash-es@4.17.21:
-    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
@@ -11281,8 +11275,6 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
-
-  lodash-es@4.17.21: {}
 
   lodash.camelcase@4.3.0: {}
 

--- a/src/runtime/emit-code.ts
+++ b/src/runtime/emit-code.ts
@@ -2,7 +2,7 @@ import { SourceType, SNIPPET_RENDERED } from '@storybook/docs-tools';
 
 import { addons } from '@storybook/preview-api';
 import type { StoryObj } from '@storybook/svelte';
-import get from 'lodash-es/get';
+import { get } from 'es-toolkit/compat';
 import type { ComponentProps } from 'svelte';
 import type { EmptyObject } from 'type-fest';
 


### PR DESCRIPTION
#186 introduces usage of [`es-toolkit`](https://es-toolkit.slash.page/). This PR replaces the one place we use `lodash-es` (`get`) with the compat `get` from `es-toolkit`, to remove lodash from the dependency list.

The emit code functionality is [heavily unit tested](https://github.com/storybookjs/addon-svelte-csf/blob/7bad5ea26c6320411537371f1dcda267cc2b6821/src/runtime/emit-code.test.ts#L93), and everything seems to work without issues.