### PR TITLE
chore: Remove `@storybook/types` dependency in favor of `storybook/types/internal`

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@storybook/csf": "^0.1.11",
     "@storybook/docs-tools": "^8.0.0",
     "@storybook/node-logger": "^8.0.0",
-    "@storybook/types": "^8.0.0",
     "dedent": "^1.5.3",
     "esrap": "^1.2.2",
     "lodash-es": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@storybook/node-logger':
         specifier: ^8.0.0
         version: 8.2.2(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))
-      '@storybook/types':
-        specifier: ^8.0.0
-        version: 8.2.2(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))
       dedent:
         specifier: ^1.5.3
         version: 1.5.3
@@ -1495,11 +1492,6 @@ packages:
 
   '@storybook/test@8.2.2':
     resolution: {integrity: sha512-X2qAKErjTh1X7XLAZqCMtU0ZK8JuwdKmgiqU0oXWxIDmCX6/Dm9ZIcdMZHs/S+K/UnIByjNlQpTShLVfRUeN1w==}
-    peerDependencies:
-      storybook: ^8.2.2
-
-  '@storybook/types@8.2.2':
-    resolution: {integrity: sha512-SlwfeluJC/FgTPIda4ivjSeCyi7G8krWZDX/FzM3k6MtZdDsV9vdg1ttBObugn6AESy4Zh+unePo7SbD8/sSfQ==}
     peerDependencies:
       storybook: ^8.2.2
 
@@ -7841,10 +7833,6 @@ snapshots:
       - '@types/jest'
       - jest
       - vitest
-
-  '@storybook/types@8.2.2(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))':
-    dependencies:
-      storybook: 8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7))
 
   '@sveltejs/package@2.3.2(svelte@5.0.0-next.215)(typescript@5.5.2)':
     dependencies:

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import type { PlayFunctionContext } from '@storybook/types';
+import type { PlayFunctionContext } from 'storybook/internal/types';
 import type { Component, ComponentProps, Snippet } from 'svelte';
 import type { EmptyObject, Primitive } from 'type-fest';
 import { describe, expectTypeOf, it } from 'vitest';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { Args as BaseArgs } from '@storybook/types';
+import type { Args as BaseArgs } from 'storybook/internal/types';
 import dedent from 'dedent';
 import type { EmptyObject } from 'type-fest';
 

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 
 import { combineTags } from '@storybook/csf';
-import type { IndexInput, Indexer } from '@storybook/types';
+import type { IndexInput, Indexer } from 'storybook/internal/types';
 import { preprocess } from 'svelte/compiler';
 
 import { getSvelteAST } from '#parser/ast';

--- a/src/runtime/Story.svelte
+++ b/src/runtime/Story.svelte
@@ -5,7 +5,7 @@
   lang="ts"
   generics="const TOverrideArgs extends Args, const TCmp extends Cmp, TMeta extends Meta<TCmp>"
 >
-  import type { Args } from '@storybook/types';
+  import type { Args } from 'storybook/internal/types';
   import type { Snippet } from 'svelte';
 
   import { useStoriesExtractor } from '#runtime/contexts/extractor.svelte';

--- a/src/runtime/contexts/extractor.svelte.ts
+++ b/src/runtime/contexts/extractor.svelte.ts
@@ -1,4 +1,4 @@
-import type { Args } from '@storybook/types';
+import type { Args } from 'storybook/internal/types';
 import { getContext, hasContext, setContext, type ComponentProps } from 'svelte';
 
 import { storyNameToExportName } from '#utils/identifier-utils';

--- a/src/runtime/contexts/renderer.svelte.ts
+++ b/src/runtime/contexts/renderer.svelte.ts
@@ -1,7 +1,7 @@
 import { getContext, hasContext, setContext } from 'svelte';
 
 import type { Cmp, Meta, StoryAnnotations, StoryContext } from '#types';
-import type { Args } from '@storybook/types';
+import type { Args } from 'storybook/internal/types';
 
 const CONTEXT_KEY = 'storybook-story-renderer-context';
 

--- a/src/runtime/contexts/template.svelte.ts
+++ b/src/runtime/contexts/template.svelte.ts
@@ -1,4 +1,4 @@
-import type { Args } from '@storybook/types';
+import type { Args } from 'storybook/internal/types';
 import { getContext, hasContext, setContext, type ComponentProps } from 'svelte';
 
 import type { Cmp, Meta, StoryCmp } from '#types';

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,4 +1,4 @@
-import type { PlayFunctionContext } from '@storybook/types';
+import type { PlayFunctionContext } from 'storybook/internal/types';
 import type { Component, ComponentProps } from 'svelte';
 import { describe, expectTypeOf, it } from 'vitest';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ import type {
   StoryAnnotations as BaseStoryAnnotations,
   StoryContext as BaseStoryContext,
   WebRenderer,
-} from '@storybook/types';
+} from 'storybook/internal/types';
 import type { Component, ComponentProps, Snippet } from 'svelte';
 import type { Primitive, SetOptional, Simplify } from 'type-fest';
 


### PR DESCRIPTION
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.1.7--canary.205.f0ef597.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-svelte-csf@4.1.7--canary.205.f0ef597.0
  # or 
  yarn add @storybook/addon-svelte-csf@4.1.7--canary.205.f0ef597.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

@JReinhold I need an opinion. We could update `storybook` and `@storybook/*` dependencies as drive-by to this PR.
As far I managed to find out, this change _(from `@storybook/types` to `storybook/types/internal`)_ was made in `v8.2`.