### PR TITLE
v5: Fix tags being ignored

### DIFF
--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -83,7 +83,7 @@ export const indexer: Indexer = {
         exportName,
         name,
         title: metaTitle,
-        tags: combineTags(...metaTags, ...tags),
+        tags: [...metaTags, ...tags],
       } satisfies IndexInput;
     });
   },

--- a/tests/stories/Tags.stories.svelte
+++ b/tests/stories/Tags.stories.svelte
@@ -1,6 +1,11 @@
 <script context="module">
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
+  /**
+   * Testing tags parsing in the addon's indexer.
+   * - In the sidebar, only the _"With Dev"_ story should be visible.
+   * - In docs, only the _"With Autodocs"_ story should be visible.
+   */
   const { Story } = defineMeta({
     title: 'Tags',
     parameters: {
@@ -10,10 +15,11 @@
   });
 </script>
 
-<Story name="No Tags">No tags</Story>
 
 <Story name="With Autodocs" tags={['autodocs']}>With autodocs</Story>
 
 <Story name="With Dev" tags={['dev']}>With dev</Story>
 
 <Story name="With Test" tags={['test']}>With test</Story>
+
+<Story name="No Tags">No tags</Story>

--- a/tests/stories/Tags.stories.svelte
+++ b/tests/stories/Tags.stories.svelte
@@ -1,0 +1,19 @@
+<script context="module">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  const { Story } = defineMeta({
+    title: 'Tags',
+    parameters: {
+      controls: { disable: true },
+    },
+    tags: ['!dev', '!autodocs', '!test'],
+  });
+</script>
+
+<Story name="No Tags">No tags</Story>
+
+<Story name="With Autodocs" tags={['autodocs']}>With autodocs</Story>
+
+<Story name="With Dev" tags={['dev']}>With dev</Story>
+
+<Story name="With Test" tags={['test']}>With test</Story>


### PR DESCRIPTION
Fixes https://github.com/storybookjs/addon-svelte-csf/issues/200

We can't and shouldn't "precombine" tags in the indexer, we should just pass them in, making sure they are in the right order. Storybook will internally combine the tags correctly, with the project-level tags.

Consider the following example:

- project-level: `['dev', 'test']` (this is the default)
- meta-level: `['!dev', '!test', '!autodocs']` (disable everything)
- story-level: `['test', 'autodocs']` (enable tests and docs for this specific story, still keeping sidebar disabled)

If the indexer combines the meta and story tags with `combineTags()`, they'll end up as `['test', 'autodocs']` (`'!dev'` will be omitted completely, because it's not enabled). Then this gets passed to Storybook, which combines them with project-level tags, resulting in `['dev', 'test', 'autodocs']`. This is wrong, `'dev'` should not be there as it was disabled at the meta-level, but Storybook doesn't know that because the indexer already omitted `'!dev'`.

If we instead don't combine anything and let Storybook do it _with the project level tags_, it will get the following series:

`['dev', 'test', '!dev', '!test', '!autodocs', 'test', 'autodocs']`. Parsing these sequentially will yield the correct result: `['test', 'autodocs']`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.1.7--canary.206.e4feeae.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-svelte-csf@4.1.7--canary.206.e4feeae.0
  # or 
  yarn add @storybook/addon-svelte-csf@4.1.7--canary.206.e4feeae.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
