### PR TITLE
refactor: Improve AST-related types readability & fix existing issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "rimraf": "^5.0.7",
     "rollup": "^4.18.0",
     "storybook": "^8.2.2",
-    "svelte": "5.0.0-next.215",
+    "svelte": "5.0.0-next.243",
     "svelte-check": "^3.8.4",
     "tslib": "^2.6.3",
     "type-fest": "^4.20.1",
@@ -109,7 +109,7 @@
   "peerDependencies": {
     "@storybook/svelte": "^8.0.0",
     "@sveltejs/vite-plugin-svelte": "^4.0.0-next.0 || ^4.0.0",
-    "svelte": "^5.0.0-next.117 || ^5.0.0",
+    "svelte": "^5.0.0-next.243 || ^5.0.0",
     "vite": "^5.0.0"
   },
   "packageManager": "pnpm@9.1.3+sha512.7c2ea089e1a6af306409c4fc8c4f0897bdac32b772016196c469d9428f1fe2d5a21daf8ad6512762654ac645b5d9136bb210ec9a00afa8dbc4677843ba362ecd",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "rimraf": "^5.0.7",
     "rollup": "^4.18.0",
     "storybook": "^8.2.2",
-    "svelte": "5.0.0-next.243",
+    "svelte": "5.0.0-next.244",
     "svelte-check": "^3.8.4",
     "tslib": "^2.6.3",
     "type-fest": "^4.20.1",
@@ -109,7 +109,7 @@
   "peerDependencies": {
     "@storybook/svelte": "^8.0.0",
     "@sveltejs/vite-plugin-svelte": "^4.0.0-next.0 || ^4.0.0",
-    "svelte": "^5.0.0-next.243 || ^5.0.0",
+    "svelte": "^5.0.0-next.244 || ^5.0.0",
     "vite": "^5.0.0"
   },
   "packageManager": "pnpm@9.1.3+sha512.7c2ea089e1a6af306409c4fc8c4f0897bdac32b772016196c469d9428f1fe2d5a21daf8ad6512762654ac645b5d9136bb210ec9a00afa8dbc4677843ba362ecd",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,19 +62,19 @@ importers:
         version: 8.2.2(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))
       '@storybook/svelte':
         specifier: ^8.2.2
-        version: 8.2.2(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.215)
+        version: 8.2.2(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.243)
       '@storybook/svelte-vite':
         specifier: ^8.2.2
-        version: 8.2.2(@babel/core@7.24.7)(@sveltejs/vite-plugin-svelte@4.0.0-next.3(svelte@5.0.0-next.215)(vite@5.3.2(@types/node@20.14.9)))(postcss@8.4.39)(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.215)(typescript@5.5.2)(vite@5.3.2(@types/node@20.14.9))
+        version: 8.2.2(@babel/core@7.24.7)(@sveltejs/vite-plugin-svelte@4.0.0-next.3(svelte@5.0.0-next.243)(vite@5.3.2(@types/node@20.14.9)))(postcss@8.4.39)(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.243)(typescript@5.5.2)(vite@5.3.2(@types/node@20.14.9))
       '@storybook/test':
         specifier: ^8.2.2
         version: 8.2.2(@jest/globals@29.7.0)(jest@29.7.0(@types/node@20.14.9))(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(vitest@1.6.0(@types/node@20.14.9)(@vitest/ui@1.6.0)(jsdom@24.1.0))
       '@sveltejs/package':
         specifier: ^2.3.2
-        version: 2.3.2(svelte@5.0.0-next.215)(typescript@5.5.2)
+        version: 2.3.2(svelte@5.0.0-next.243)(typescript@5.5.2)
       '@sveltejs/vite-plugin-svelte':
         specifier: 4.0.0-next.3
-        version: 4.0.0-next.3(svelte@5.0.0-next.215)(vite@5.3.2(@types/node@20.14.9))
+        version: 4.0.0-next.3(svelte@5.0.0-next.243)(vite@5.3.2(@types/node@20.14.9))
       '@tsconfig/svelte':
         specifier: ^5.0.4
         version: 5.0.4
@@ -110,7 +110,7 @@ importers:
         version: 3.3.2
       prettier-plugin-svelte:
         specifier: ^3.2.5
-        version: 3.2.5(prettier@3.3.2)(svelte@5.0.0-next.215)
+        version: 3.2.5(prettier@3.3.2)(svelte@5.0.0-next.243)
       rimraf:
         specifier: ^5.0.7
         version: 5.0.7
@@ -121,11 +121,11 @@ importers:
         specifier: ^8.2.2
         version: 8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7))
       svelte:
-        specifier: 5.0.0-next.215
-        version: 5.0.0-next.215
+        specifier: 5.0.0-next.243
+        version: 5.0.0-next.243
       svelte-check:
         specifier: ^3.8.4
-        version: 3.8.4(@babel/core@7.24.7)(postcss@8.4.39)(svelte@5.0.0-next.215)
+        version: 3.8.4(@babel/core@7.24.7)(postcss@8.4.39)(svelte@5.0.0-next.243)
       tslib:
         specifier: ^2.6.3
         version: 2.6.3
@@ -137,7 +137,7 @@ importers:
         version: 5.5.2
       typescript-svelte-plugin:
         specifier: ^0.3.39
-        version: 0.3.39(svelte@5.0.0-next.215)(typescript@5.5.2)
+        version: 0.3.39(svelte@5.0.0-next.243)(typescript@5.5.2)
       vite:
         specifier: ^5.3.2
         version: 5.3.2(@types/node@20.14.9)
@@ -1113,6 +1113,9 @@ packages:
   '@jridgewell/sourcemap-codec@1.4.15':
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
 
+  '@jridgewell/sourcemap-codec@1.5.0':
+    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
@@ -1890,6 +1893,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.12.1:
+    resolution: {integrity: sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -2050,8 +2058,9 @@ packages:
   axobject-query@3.2.1:
     resolution: {integrity: sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==}
 
-  axobject-query@4.0.0:
-    resolution: {integrity: sha512-+60uv1hiVFhHZeO+Lz0RYzsVHy5Wr1ayX0mwda9KPDVLNJgZ1T9Ny7VmFbLDzxsH0D87I86vgj3gFrjTJUYznw==}
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
 
   babel-core@7.0.0-bridge.0:
     resolution: {integrity: sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==}
@@ -3921,6 +3930,9 @@ packages:
   magic-string@0.30.10:
     resolution: {integrity: sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==}
 
+  magic-string@0.30.11:
+    resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
+
   make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
     engines: {node: '>=6'}
@@ -5245,8 +5257,8 @@ packages:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
       typescript: ^4.9.4 || ^5.0.0
 
-  svelte@5.0.0-next.215:
-    resolution: {integrity: sha512-jLCVHMrbiKQvXO2zGl6E/y7F7A5r4OPJBimqNWPuffrimk35j7SSKbMVGVAk6FesxLABxy760ZtnjRQ0XiSCDQ==}
+  svelte@5.0.0-next.243:
+    resolution: {integrity: sha512-+oXjRInUyBfZXAEY8hmpf3F0eghAVCoWasotz1iOp2G5CyH4KR7jPxWOgjbgsgpL4zlMiN32MEYU1+I+QsC+nQ==}
     engines: {node: '>=18'}
 
   sveltedoc-parser@4.2.1:
@@ -7267,6 +7279,8 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.4.15': {}
 
+  '@jridgewell/sourcemap-codec@1.5.0': {}
+
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
@@ -7786,15 +7800,15 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7))
 
-  '@storybook/svelte-vite@8.2.2(@babel/core@7.24.7)(@sveltejs/vite-plugin-svelte@4.0.0-next.3(svelte@5.0.0-next.215)(vite@5.3.2(@types/node@20.14.9)))(postcss@8.4.39)(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.215)(typescript@5.5.2)(vite@5.3.2(@types/node@20.14.9))':
+  '@storybook/svelte-vite@8.2.2(@babel/core@7.24.7)(@sveltejs/vite-plugin-svelte@4.0.0-next.3(svelte@5.0.0-next.243)(vite@5.3.2(@types/node@20.14.9)))(postcss@8.4.39)(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.243)(typescript@5.5.2)(vite@5.3.2(@types/node@20.14.9))':
     dependencies:
       '@storybook/builder-vite': 8.2.2(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(typescript@5.5.2)(vite@5.3.2(@types/node@20.14.9))
-      '@storybook/svelte': 8.2.2(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.215)
-      '@sveltejs/vite-plugin-svelte': 4.0.0-next.3(svelte@5.0.0-next.215)(vite@5.3.2(@types/node@20.14.9))
+      '@storybook/svelte': 8.2.2(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.243)
+      '@sveltejs/vite-plugin-svelte': 4.0.0-next.3(svelte@5.0.0-next.243)(vite@5.3.2(@types/node@20.14.9))
       magic-string: 0.30.10
       storybook: 8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7))
-      svelte: 5.0.0-next.215
-      svelte-preprocess: 6.0.2(@babel/core@7.24.7)(postcss@8.4.39)(svelte@5.0.0-next.215)(typescript@5.5.2)
+      svelte: 5.0.0-next.243
+      svelte-preprocess: 6.0.2(@babel/core@7.24.7)(postcss@8.4.39)(svelte@5.0.0-next.243)(typescript@5.5.2)
       sveltedoc-parser: 4.2.1
       ts-dedent: 2.2.0
       vite: 5.3.2(@types/node@20.14.9)
@@ -7813,11 +7827,11 @@ snapshots:
       - typescript
       - vite-plugin-glimmerx
 
-  '@storybook/svelte@8.2.2(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.215)':
+  '@storybook/svelte@8.2.2(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.243)':
     dependencies:
       '@storybook/global': 5.0.0
       storybook: 8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7))
-      svelte: 5.0.0-next.215
+      svelte: 5.0.0-next.243
       sveltedoc-parser: 4.2.1
       ts-dedent: 2.2.0
       type-fest: 2.19.0
@@ -7846,34 +7860,34 @@ snapshots:
     dependencies:
       storybook: 8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7))
 
-  '@sveltejs/package@2.3.2(svelte@5.0.0-next.215)(typescript@5.5.2)':
+  '@sveltejs/package@2.3.2(svelte@5.0.0-next.243)(typescript@5.5.2)':
     dependencies:
       chokidar: 3.6.0
       kleur: 4.1.5
       sade: 1.8.1
       semver: 7.6.2
-      svelte: 5.0.0-next.215
-      svelte2tsx: 0.7.9(svelte@5.0.0-next.215)(typescript@5.5.2)
+      svelte: 5.0.0-next.243
+      svelte2tsx: 0.7.9(svelte@5.0.0-next.243)(typescript@5.5.2)
     transitivePeerDependencies:
       - typescript
 
-  '@sveltejs/vite-plugin-svelte-inspector@3.0.0-next.1(@sveltejs/vite-plugin-svelte@4.0.0-next.3(svelte@5.0.0-next.215)(vite@5.3.2(@types/node@20.14.9)))(svelte@5.0.0-next.215)(vite@5.3.2(@types/node@20.14.9))':
+  '@sveltejs/vite-plugin-svelte-inspector@3.0.0-next.1(@sveltejs/vite-plugin-svelte@4.0.0-next.3(svelte@5.0.0-next.243)(vite@5.3.2(@types/node@20.14.9)))(svelte@5.0.0-next.243)(vite@5.3.2(@types/node@20.14.9))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.0-next.3(svelte@5.0.0-next.215)(vite@5.3.2(@types/node@20.14.9))
+      '@sveltejs/vite-plugin-svelte': 4.0.0-next.3(svelte@5.0.0-next.243)(vite@5.3.2(@types/node@20.14.9))
       debug: 4.3.5
-      svelte: 5.0.0-next.215
+      svelte: 5.0.0-next.243
       vite: 5.3.2(@types/node@20.14.9)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@4.0.0-next.3(svelte@5.0.0-next.215)(vite@5.3.2(@types/node@20.14.9))':
+  '@sveltejs/vite-plugin-svelte@4.0.0-next.3(svelte@5.0.0-next.243)(vite@5.3.2(@types/node@20.14.9))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 3.0.0-next.1(@sveltejs/vite-plugin-svelte@4.0.0-next.3(svelte@5.0.0-next.215)(vite@5.3.2(@types/node@20.14.9)))(svelte@5.0.0-next.215)(vite@5.3.2(@types/node@20.14.9))
+      '@sveltejs/vite-plugin-svelte-inspector': 3.0.0-next.1(@sveltejs/vite-plugin-svelte@4.0.0-next.3(svelte@5.0.0-next.243)(vite@5.3.2(@types/node@20.14.9)))(svelte@5.0.0-next.243)(vite@5.3.2(@types/node@20.14.9))
       debug: 4.3.5
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.10
-      svelte: 5.0.0-next.215
+      svelte: 5.0.0-next.243
       vite: 5.3.2(@types/node@20.14.9)
       vitefu: 0.2.5(vite@5.3.2(@types/node@20.14.9))
     transitivePeerDependencies:
@@ -8301,9 +8315,9 @@ snapshots:
     dependencies:
       acorn: 8.12.0
 
-  acorn-typescript@1.4.13(acorn@8.12.0):
+  acorn-typescript@1.4.13(acorn@8.12.1):
     dependencies:
-      acorn: 8.12.0
+      acorn: 8.12.1
 
   acorn-walk@8.3.2: {}
 
@@ -8316,6 +8330,8 @@ snapshots:
   acorn@8.11.3: {}
 
   acorn@8.12.0: {}
+
+  acorn@8.12.1: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -8516,9 +8532,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  axobject-query@4.0.0:
-    dependencies:
-      dequal: 2.0.3
+  axobject-query@4.1.0: {}
 
   babel-core@7.0.0-bridge.0(@babel/core@7.24.7):
     dependencies:
@@ -10908,6 +10922,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
 
+  magic-string@0.30.11:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
+
   make-dir@2.1.0:
     dependencies:
       pify: 4.0.1
@@ -11726,10 +11744,10 @@ snapshots:
     dependencies:
       fast-diff: 1.3.0
 
-  prettier-plugin-svelte@3.2.5(prettier@3.3.2)(svelte@5.0.0-next.215):
+  prettier-plugin-svelte@3.2.5(prettier@3.3.2)(svelte@5.0.0-next.243):
     dependencies:
       prettier: 3.3.2
-      svelte: 5.0.0-next.215
+      svelte: 5.0.0-next.243
 
   prettier@3.3.2: {}
 
@@ -12563,14 +12581,14 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@3.8.4(@babel/core@7.24.7)(postcss@8.4.39)(svelte@5.0.0-next.215):
+  svelte-check@3.8.4(@babel/core@7.24.7)(postcss@8.4.39)(svelte@5.0.0-next.243):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 3.6.0
       picocolors: 1.0.1
       sade: 1.8.1
-      svelte: 5.0.0-next.215
-      svelte-preprocess: 6.0.2(@babel/core@7.24.7)(postcss@8.4.39)(svelte@5.0.0-next.215)(typescript@5.5.2)
+      svelte: 5.0.0-next.243
+      svelte-preprocess: 6.0.2(@babel/core@7.24.7)(postcss@8.4.39)(svelte@5.0.0-next.243)(typescript@5.5.2)
       typescript: 5.5.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -12583,42 +12601,42 @@ snapshots:
       - stylus
       - sugarss
 
-  svelte-preprocess@6.0.2(@babel/core@7.24.7)(postcss@8.4.39)(svelte@5.0.0-next.215)(typescript@5.5.2):
+  svelte-preprocess@6.0.2(@babel/core@7.24.7)(postcss@8.4.39)(svelte@5.0.0-next.243)(typescript@5.5.2):
     dependencies:
-      svelte: 5.0.0-next.215
+      svelte: 5.0.0-next.243
     optionalDependencies:
       '@babel/core': 7.24.7
       postcss: 8.4.39
       typescript: 5.5.2
 
-  svelte2tsx@0.7.13(svelte@5.0.0-next.215)(typescript@5.5.2):
+  svelte2tsx@0.7.13(svelte@5.0.0-next.243)(typescript@5.5.2):
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
-      svelte: 5.0.0-next.215
+      svelte: 5.0.0-next.243
       typescript: 5.5.2
 
-  svelte2tsx@0.7.9(svelte@5.0.0-next.215)(typescript@5.5.2):
+  svelte2tsx@0.7.9(svelte@5.0.0-next.243)(typescript@5.5.2):
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
-      svelte: 5.0.0-next.215
+      svelte: 5.0.0-next.243
       typescript: 5.5.2
 
-  svelte@5.0.0-next.215:
+  svelte@5.0.0-next.243:
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
       '@types/estree': 1.0.5
-      acorn: 8.12.0
-      acorn-typescript: 1.4.13(acorn@8.12.0)
+      acorn: 8.12.1
+      acorn-typescript: 1.4.13(acorn@8.12.1)
       aria-query: 5.3.0
-      axobject-query: 4.0.0
+      axobject-query: 4.1.0
       esm-env: 1.0.0
       esrap: 1.2.2
       is-reference: 3.0.2
       locate-character: 3.0.0
-      magic-string: 0.30.10
+      magic-string: 0.30.11
       zimmerframe: 1.1.2
 
   sveltedoc-parser@4.2.1:
@@ -12846,10 +12864,10 @@ snapshots:
 
   typescript-memoize@1.1.1: {}
 
-  typescript-svelte-plugin@0.3.39(svelte@5.0.0-next.215)(typescript@5.5.2):
+  typescript-svelte-plugin@0.3.39(svelte@5.0.0-next.243)(typescript@5.5.2):
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
-      svelte2tsx: 0.7.13(svelte@5.0.0-next.215)(typescript@5.5.2)
+      svelte2tsx: 0.7.13(svelte@5.0.0-next.243)(typescript@5.5.2)
     transitivePeerDependencies:
       - svelte
       - typescript

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,19 +62,19 @@ importers:
         version: 8.2.2(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))
       '@storybook/svelte':
         specifier: ^8.2.2
-        version: 8.2.2(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.243)
+        version: 8.2.2(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.244)
       '@storybook/svelte-vite':
         specifier: ^8.2.2
-        version: 8.2.2(@babel/core@7.24.7)(@sveltejs/vite-plugin-svelte@4.0.0-next.3(svelte@5.0.0-next.243)(vite@5.3.2(@types/node@20.14.9)))(postcss@8.4.39)(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.243)(typescript@5.5.2)(vite@5.3.2(@types/node@20.14.9))
+        version: 8.2.2(@babel/core@7.24.7)(@sveltejs/vite-plugin-svelte@4.0.0-next.3(svelte@5.0.0-next.244)(vite@5.3.2(@types/node@20.14.9)))(postcss@8.4.39)(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.244)(typescript@5.5.2)(vite@5.3.2(@types/node@20.14.9))
       '@storybook/test':
         specifier: ^8.2.2
         version: 8.2.2(@jest/globals@29.7.0)(jest@29.7.0(@types/node@20.14.9))(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(vitest@1.6.0(@types/node@20.14.9)(@vitest/ui@1.6.0)(jsdom@24.1.0))
       '@sveltejs/package':
         specifier: ^2.3.2
-        version: 2.3.2(svelte@5.0.0-next.243)(typescript@5.5.2)
+        version: 2.3.2(svelte@5.0.0-next.244)(typescript@5.5.2)
       '@sveltejs/vite-plugin-svelte':
         specifier: 4.0.0-next.3
-        version: 4.0.0-next.3(svelte@5.0.0-next.243)(vite@5.3.2(@types/node@20.14.9))
+        version: 4.0.0-next.3(svelte@5.0.0-next.244)(vite@5.3.2(@types/node@20.14.9))
       '@tsconfig/svelte':
         specifier: ^5.0.4
         version: 5.0.4
@@ -110,7 +110,7 @@ importers:
         version: 3.3.2
       prettier-plugin-svelte:
         specifier: ^3.2.5
-        version: 3.2.5(prettier@3.3.2)(svelte@5.0.0-next.243)
+        version: 3.2.5(prettier@3.3.2)(svelte@5.0.0-next.244)
       rimraf:
         specifier: ^5.0.7
         version: 5.0.7
@@ -121,11 +121,11 @@ importers:
         specifier: ^8.2.2
         version: 8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7))
       svelte:
-        specifier: 5.0.0-next.243
-        version: 5.0.0-next.243
+        specifier: 5.0.0-next.244
+        version: 5.0.0-next.244
       svelte-check:
         specifier: ^3.8.4
-        version: 3.8.4(@babel/core@7.24.7)(postcss@8.4.39)(svelte@5.0.0-next.243)
+        version: 3.8.4(@babel/core@7.24.7)(postcss@8.4.39)(svelte@5.0.0-next.244)
       tslib:
         specifier: ^2.6.3
         version: 2.6.3
@@ -137,7 +137,7 @@ importers:
         version: 5.5.2
       typescript-svelte-plugin:
         specifier: ^0.3.39
-        version: 0.3.39(svelte@5.0.0-next.243)(typescript@5.5.2)
+        version: 0.3.39(svelte@5.0.0-next.244)(typescript@5.5.2)
       vite:
         specifier: ^5.3.2
         version: 5.3.2(@types/node@20.14.9)
@@ -5257,8 +5257,8 @@ packages:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
       typescript: ^4.9.4 || ^5.0.0
 
-  svelte@5.0.0-next.243:
-    resolution: {integrity: sha512-+oXjRInUyBfZXAEY8hmpf3F0eghAVCoWasotz1iOp2G5CyH4KR7jPxWOgjbgsgpL4zlMiN32MEYU1+I+QsC+nQ==}
+  svelte@5.0.0-next.244:
+    resolution: {integrity: sha512-whSOcKdpuAFd5xD9J2EhuHeRs4J4nHis6NSUKRXpC3HQoCmsoKhyIldMjiv6QFkQpe6QMsid8lwvgLXkZTSC/A==}
     engines: {node: '>=18'}
 
   sveltedoc-parser@4.2.1:
@@ -7800,15 +7800,15 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7))
 
-  '@storybook/svelte-vite@8.2.2(@babel/core@7.24.7)(@sveltejs/vite-plugin-svelte@4.0.0-next.3(svelte@5.0.0-next.243)(vite@5.3.2(@types/node@20.14.9)))(postcss@8.4.39)(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.243)(typescript@5.5.2)(vite@5.3.2(@types/node@20.14.9))':
+  '@storybook/svelte-vite@8.2.2(@babel/core@7.24.7)(@sveltejs/vite-plugin-svelte@4.0.0-next.3(svelte@5.0.0-next.244)(vite@5.3.2(@types/node@20.14.9)))(postcss@8.4.39)(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.244)(typescript@5.5.2)(vite@5.3.2(@types/node@20.14.9))':
     dependencies:
       '@storybook/builder-vite': 8.2.2(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(typescript@5.5.2)(vite@5.3.2(@types/node@20.14.9))
-      '@storybook/svelte': 8.2.2(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.243)
-      '@sveltejs/vite-plugin-svelte': 4.0.0-next.3(svelte@5.0.0-next.243)(vite@5.3.2(@types/node@20.14.9))
+      '@storybook/svelte': 8.2.2(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.244)
+      '@sveltejs/vite-plugin-svelte': 4.0.0-next.3(svelte@5.0.0-next.244)(vite@5.3.2(@types/node@20.14.9))
       magic-string: 0.30.10
       storybook: 8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7))
-      svelte: 5.0.0-next.243
-      svelte-preprocess: 6.0.2(@babel/core@7.24.7)(postcss@8.4.39)(svelte@5.0.0-next.243)(typescript@5.5.2)
+      svelte: 5.0.0-next.244
+      svelte-preprocess: 6.0.2(@babel/core@7.24.7)(postcss@8.4.39)(svelte@5.0.0-next.244)(typescript@5.5.2)
       sveltedoc-parser: 4.2.1
       ts-dedent: 2.2.0
       vite: 5.3.2(@types/node@20.14.9)
@@ -7827,11 +7827,11 @@ snapshots:
       - typescript
       - vite-plugin-glimmerx
 
-  '@storybook/svelte@8.2.2(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.243)':
+  '@storybook/svelte@8.2.2(storybook@8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.244)':
     dependencies:
       '@storybook/global': 5.0.0
       storybook: 8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7))
-      svelte: 5.0.0-next.243
+      svelte: 5.0.0-next.244
       sveltedoc-parser: 4.2.1
       ts-dedent: 2.2.0
       type-fest: 2.19.0
@@ -7860,34 +7860,34 @@ snapshots:
     dependencies:
       storybook: 8.2.2(@babel/preset-env@7.24.7(@babel/core@7.24.7))
 
-  '@sveltejs/package@2.3.2(svelte@5.0.0-next.243)(typescript@5.5.2)':
+  '@sveltejs/package@2.3.2(svelte@5.0.0-next.244)(typescript@5.5.2)':
     dependencies:
       chokidar: 3.6.0
       kleur: 4.1.5
       sade: 1.8.1
       semver: 7.6.2
-      svelte: 5.0.0-next.243
-      svelte2tsx: 0.7.9(svelte@5.0.0-next.243)(typescript@5.5.2)
+      svelte: 5.0.0-next.244
+      svelte2tsx: 0.7.9(svelte@5.0.0-next.244)(typescript@5.5.2)
     transitivePeerDependencies:
       - typescript
 
-  '@sveltejs/vite-plugin-svelte-inspector@3.0.0-next.1(@sveltejs/vite-plugin-svelte@4.0.0-next.3(svelte@5.0.0-next.243)(vite@5.3.2(@types/node@20.14.9)))(svelte@5.0.0-next.243)(vite@5.3.2(@types/node@20.14.9))':
+  '@sveltejs/vite-plugin-svelte-inspector@3.0.0-next.1(@sveltejs/vite-plugin-svelte@4.0.0-next.3(svelte@5.0.0-next.244)(vite@5.3.2(@types/node@20.14.9)))(svelte@5.0.0-next.244)(vite@5.3.2(@types/node@20.14.9))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.0-next.3(svelte@5.0.0-next.243)(vite@5.3.2(@types/node@20.14.9))
+      '@sveltejs/vite-plugin-svelte': 4.0.0-next.3(svelte@5.0.0-next.244)(vite@5.3.2(@types/node@20.14.9))
       debug: 4.3.5
-      svelte: 5.0.0-next.243
+      svelte: 5.0.0-next.244
       vite: 5.3.2(@types/node@20.14.9)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@4.0.0-next.3(svelte@5.0.0-next.243)(vite@5.3.2(@types/node@20.14.9))':
+  '@sveltejs/vite-plugin-svelte@4.0.0-next.3(svelte@5.0.0-next.244)(vite@5.3.2(@types/node@20.14.9))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 3.0.0-next.1(@sveltejs/vite-plugin-svelte@4.0.0-next.3(svelte@5.0.0-next.243)(vite@5.3.2(@types/node@20.14.9)))(svelte@5.0.0-next.243)(vite@5.3.2(@types/node@20.14.9))
+      '@sveltejs/vite-plugin-svelte-inspector': 3.0.0-next.1(@sveltejs/vite-plugin-svelte@4.0.0-next.3(svelte@5.0.0-next.244)(vite@5.3.2(@types/node@20.14.9)))(svelte@5.0.0-next.244)(vite@5.3.2(@types/node@20.14.9))
       debug: 4.3.5
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.10
-      svelte: 5.0.0-next.243
+      svelte: 5.0.0-next.244
       vite: 5.3.2(@types/node@20.14.9)
       vitefu: 0.2.5(vite@5.3.2(@types/node@20.14.9))
     transitivePeerDependencies:
@@ -11744,10 +11744,10 @@ snapshots:
     dependencies:
       fast-diff: 1.3.0
 
-  prettier-plugin-svelte@3.2.5(prettier@3.3.2)(svelte@5.0.0-next.243):
+  prettier-plugin-svelte@3.2.5(prettier@3.3.2)(svelte@5.0.0-next.244):
     dependencies:
       prettier: 3.3.2
-      svelte: 5.0.0-next.243
+      svelte: 5.0.0-next.244
 
   prettier@3.3.2: {}
 
@@ -12581,14 +12581,14 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@3.8.4(@babel/core@7.24.7)(postcss@8.4.39)(svelte@5.0.0-next.243):
+  svelte-check@3.8.4(@babel/core@7.24.7)(postcss@8.4.39)(svelte@5.0.0-next.244):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 3.6.0
       picocolors: 1.0.1
       sade: 1.8.1
-      svelte: 5.0.0-next.243
-      svelte-preprocess: 6.0.2(@babel/core@7.24.7)(postcss@8.4.39)(svelte@5.0.0-next.243)(typescript@5.5.2)
+      svelte: 5.0.0-next.244
+      svelte-preprocess: 6.0.2(@babel/core@7.24.7)(postcss@8.4.39)(svelte@5.0.0-next.244)(typescript@5.5.2)
       typescript: 5.5.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -12601,29 +12601,29 @@ snapshots:
       - stylus
       - sugarss
 
-  svelte-preprocess@6.0.2(@babel/core@7.24.7)(postcss@8.4.39)(svelte@5.0.0-next.243)(typescript@5.5.2):
+  svelte-preprocess@6.0.2(@babel/core@7.24.7)(postcss@8.4.39)(svelte@5.0.0-next.244)(typescript@5.5.2):
     dependencies:
-      svelte: 5.0.0-next.243
+      svelte: 5.0.0-next.244
     optionalDependencies:
       '@babel/core': 7.24.7
       postcss: 8.4.39
       typescript: 5.5.2
 
-  svelte2tsx@0.7.13(svelte@5.0.0-next.243)(typescript@5.5.2):
+  svelte2tsx@0.7.13(svelte@5.0.0-next.244)(typescript@5.5.2):
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
-      svelte: 5.0.0-next.243
+      svelte: 5.0.0-next.244
       typescript: 5.5.2
 
-  svelte2tsx@0.7.9(svelte@5.0.0-next.243)(typescript@5.5.2):
+  svelte2tsx@0.7.9(svelte@5.0.0-next.244)(typescript@5.5.2):
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
-      svelte: 5.0.0-next.243
+      svelte: 5.0.0-next.244
       typescript: 5.5.2
 
-  svelte@5.0.0-next.243:
+  svelte@5.0.0-next.244:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -12864,10 +12864,10 @@ snapshots:
 
   typescript-memoize@1.1.1: {}
 
-  typescript-svelte-plugin@0.3.39(svelte@5.0.0-next.243)(typescript@5.5.2):
+  typescript-svelte-plugin@0.3.39(svelte@5.0.0-next.244)(typescript@5.5.2):
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
-      svelte2tsx: 0.7.13(svelte@5.0.0-next.243)(typescript@5.5.2)
+      svelte2tsx: 0.7.13(svelte@5.0.0-next.244)(typescript@5.5.2)
     transitivePeerDependencies:
       - svelte
       - typescript

--- a/src/compiler/transform/appendix/create-export-default.test.ts
+++ b/src/compiler/transform/appendix/create-export-default.test.ts
@@ -1,8 +1,9 @@
-import type { Program } from 'estree';
 import { print } from 'esrap';
 import { describe, it } from 'vitest';
 
 import { createExportDefaultMeta } from './create-export-default';
+
+import type { ESTreeAST } from '#parser/ast';
 
 describe(createExportDefaultMeta.name, () => {
   it('creates a new export default correctly', ({ expect }) => {
@@ -12,7 +13,7 @@ describe(createExportDefaultMeta.name, () => {
           type: 'Identifier',
           name: 'meta',
         },
-      }) as unknown as Program
+      }) as unknown as ESTreeAST.Program
     ).code;
 
     expect(stringified).toMatchInlineSnapshot(`"export default meta;"`);
@@ -25,7 +26,7 @@ describe(createExportDefaultMeta.name, () => {
           type: 'Identifier',
           name: '__renamed_meta',
         },
-      }) as unknown as Program
+      }) as unknown as ESTreeAST.Program
     ).code;
 
     expect(stringified).toMatchInlineSnapshot(`"export default __renamed_meta;"`);

--- a/src/compiler/transform/appendix/create-export-default.ts
+++ b/src/compiler/transform/appendix/create-export-default.ts
@@ -1,13 +1,12 @@
-import type { ExportDefaultDeclaration } from 'estree';
-
 import type { getMetaIdentifier } from '#parser/analyse/define-meta/meta-identifier';
+import type { ESTreeAST } from '#parser/ast';
 
 interface Params {
   metaIdentifier: ReturnType<typeof getMetaIdentifier>;
   filename?: string;
 }
 
-export function createExportDefaultMeta(params: Params): ExportDefaultDeclaration {
+export function createExportDefaultMeta(params: Params): ESTreeAST.ExportDefaultDeclaration {
   const { metaIdentifier } = params;
 
   return {

--- a/src/compiler/transform/appendix/create-export-order.ts
+++ b/src/compiler/transform/appendix/create-export-order.ts
@@ -1,13 +1,12 @@
-import type { ExportNamedDeclaration } from 'estree';
-
 import type { getStoriesIdentifiers } from '#parser/analyse/story/attributes/identifiers';
+import type { ESTreeAST } from '#parser/ast';
 
 interface Params {
   storyIdentifiers: ReturnType<typeof getStoriesIdentifiers>;
   filename?: string;
 }
 
-export function createExportOrderVariable(params: Params): ExportNamedDeclaration {
+export function createExportOrderVariable(params: Params): ESTreeAST.ExportNamedDeclaration {
   const { storyIdentifiers } = params;
 
   const exported = {

--- a/src/compiler/transform/appendix/create-import.ts
+++ b/src/compiler/transform/appendix/create-import.ts
@@ -1,10 +1,11 @@
 import pkg from '@storybook/addon-svelte-csf/package.json' with { type: 'json' };
-import type { ImportDeclaration } from 'estree';
+
+import type { ESTreeAST } from '#parser/ast';
 
 /**
  * The export is defined in the `package.json` export map
  */
-export function createRuntimeStoriesImport(): ImportDeclaration {
+export function createRuntimeStoriesImport(): ESTreeAST.ImportDeclaration {
   const imported = {
     type: 'Identifier',
     // WARN: Tempting to use `createRuntimeStories.name` here.

--- a/src/compiler/transform/appendix/create-named-export-story.test.ts
+++ b/src/compiler/transform/appendix/create-named-export-story.test.ts
@@ -1,9 +1,10 @@
-import type { Program } from 'estree';
 import { print } from 'esrap';
 import { describe, it } from 'vitest';
 
 import { createNamedExportStory } from './create-named-export-story';
 import { createVariableFromRuntimeStoriesCall } from './create-variable-from-runtime-stories-call';
+
+import type { ESTreeAST } from '#parser/ast';
 
 describe(createNamedExportStory.name, () => {
   it('correctly creates a variable with named exports order', ({ expect }) => {
@@ -28,7 +29,7 @@ describe(createNamedExportStory.name, () => {
             params: [],
           },
         }),
-      }) as unknown as Program
+      }) as unknown as ESTreeAST.Program
     ).code;
 
     expect(stringified).toMatchInlineSnapshot(`"export const Default = __stories["Default"];"`);

--- a/src/compiler/transform/appendix/create-named-export-story.ts
+++ b/src/compiler/transform/appendix/create-named-export-story.ts
@@ -1,6 +1,6 @@
-import type { ExportNamedDeclaration, Identifier } from 'estree';
-
 import type { createVariableFromRuntimeStoriesCall } from './create-variable-from-runtime-stories-call';
+
+import type { ESTreeAST } from '#parser/ast';
 
 interface Params {
   exportName: string;
@@ -8,7 +8,7 @@ interface Params {
   node: ReturnType<typeof createVariableFromRuntimeStoriesCall>;
 }
 
-export function createNamedExportStory(params: Params): ExportNamedDeclaration {
+export function createNamedExportStory(params: Params): ESTreeAST.ExportNamedDeclaration {
   const { exportName, node } = params;
 
   const exported = {
@@ -49,5 +49,5 @@ export function createNamedExportStory(params: Params): ExportNamedDeclaration {
 }
 
 function getNameFromVariable(node: Params['node']): string {
-  return (node.declarations[0].id as Identifier).name;
+  return (node.declarations[0].id as ESTreeAST.Identifier).name;
 }

--- a/src/compiler/transform/appendix/create-variable-from-runtime-stories-call.ts
+++ b/src/compiler/transform/appendix/create-variable-from-runtime-stories-call.ts
@@ -1,14 +1,15 @@
-import type { FunctionDeclaration, VariableDeclaration } from 'estree';
-
 import type { getMetaIdentifier } from '#parser/analyse/define-meta/meta-identifier';
+import type { ESTreeAST } from '#parser/ast';
 
 interface Params {
-  storiesFunctionDeclaration: FunctionDeclaration;
+  storiesFunctionDeclaration: ESTreeAST.FunctionDeclaration;
   metaIdentifier: ReturnType<typeof getMetaIdentifier>;
   filename?: string;
 }
 
-export function createVariableFromRuntimeStoriesCall(params: Params): VariableDeclaration {
+export function createVariableFromRuntimeStoriesCall(
+  params: Params
+): ESTreeAST.VariableDeclaration {
   const { storiesFunctionDeclaration, metaIdentifier } = params;
 
   return {

--- a/src/compiler/transform/define-meta/insert-description.ts
+++ b/src/compiler/transform/define-meta/insert-description.ts
@@ -1,5 +1,4 @@
 import { logger } from '@storybook/node-logger';
-import type { Comment } from 'estree';
 
 import {
   createASTObjectExpression,
@@ -11,8 +10,8 @@ import {
   getDescriptionPropertyValue,
   getDocsPropertyValue,
   getParametersPropertyValue,
-} from '../shared/description';
-
+} from '#compiler/transform/shared/description';
+import type { ESTreeAST } from '#parser/ast';
 import type { SvelteASTNodes } from '#parser/extract/svelte/nodes';
 import type { CompiledASTNodes } from '#parser/extract/compiled/nodes';
 import { getDefineMetaFirstArgumentObjectExpression } from '#parser/extract/svelte/define-meta';
@@ -131,7 +130,7 @@ export function insertDefineMetaJSDocCommentAsDescription(params: Params): void 
  * Adopted from: https://github.com/storybookjs/storybook/blob/next/code/lib/csf-tools/src/enrichCsf.ts/#L148-L164
  * Adjusted for this addon, because here we use AST format from `estree`, not `babel`.
  */
-function extractDescription(leadingComments: Comment[]) {
+function extractDescription(leadingComments: ESTreeAST.Comment[]) {
   const comments = leadingComments
     .map((comment) => {
       if (

--- a/src/compiler/transform/shared/description.ts
+++ b/src/compiler/transform/shared/description.ts
@@ -1,12 +1,15 @@
 import { logger } from '@storybook/node-logger';
 import dedent from 'dedent';
-import type { ObjectExpression, Property } from 'estree';
-import type { Component } from 'svelte/compiler';
+
+import type { ESTreeAST, SvelteAST } from '#parser/ast';
 
 /**
- * Create ESTree compliant AST node for {@link Property}
+ * Create ESTree compliant AST node for {@link ESTReeAST.Property}
  */
-export function createASTProperty(name: string, value: Property['value']): Property {
+export function createASTProperty(
+  name: string,
+  value: ESTreeAST.Property['value']
+): ESTreeAST.Property {
   return {
     type: 'Property',
     kind: 'init',
@@ -22,12 +25,12 @@ export function createASTProperty(name: string, value: Property['value']): Prope
 }
 
 /**
- * Create ESTree compliant AST node for {@link ObjectExpression} with optional array of properties.
+ * Create ESTree compliant AST node for {@link ESTreeAST.ObjectExpression} with optional array of properties.
  * By default it will create an enpty object.
  */
 export function createASTObjectExpression(
-  properties: ObjectExpression['properties'] = []
-): ObjectExpression {
+  properties: ESTreeAST.ObjectExpression['properties'] = []
+): ESTreeAST.ObjectExpression {
   return {
     type: 'ObjectExpression',
     properties,
@@ -36,9 +39,9 @@ export function createASTObjectExpression(
 
 interface FindPropertyOptions {
   name: string;
-  node: ObjectExpression;
+  node: ESTreeAST.ObjectExpression;
   filename?: string;
-  component?: Component;
+  component?: SvelteAST.Component;
 }
 
 /**
@@ -64,12 +67,12 @@ export const findPropertyParametersIndex = (options: Omit<FindPropertyOptions, '
 export const getParametersProperty = (options: Omit<FindPropertyOptions, 'name'>) => {
   const { node } = options;
 
-  return node.properties[findPropertyParametersIndex(options)] as Property;
+  return node.properties[findPropertyParametersIndex(options)] as ESTreeAST.Property;
 };
 
 export const getParametersPropertyValue = (
   options: Omit<FindPropertyOptions, 'name'>
-): ObjectExpression => {
+): ESTreeAST.ObjectExpression => {
   const { filename, component } = options;
   let property = getParametersProperty(options);
 
@@ -97,7 +100,7 @@ export const getParametersPropertyValue = (
     property.value.type === 'FunctionExpression' &&
     property.value.body.body[0].type === 'ReturnStatement'
   ) {
-    const properties: ObjectExpression['properties'] = [];
+    const properties: ESTreeAST.ObjectExpression['properties'] = [];
     if (property.value.body.body[0].argument) {
       properties.push({
         type: 'SpreadElement',
@@ -143,7 +146,9 @@ export const findPropertyDocsIndex = (options: Omit<FindPropertyOptions, 'name'>
 };
 
 export const getDocsProperty = (options: Omit<FindPropertyOptions, 'name'>) => {
-  return getParametersPropertyValue(options).properties[findPropertyDocsIndex(options)] as Property;
+  return getParametersPropertyValue(options).properties[
+    findPropertyDocsIndex(options)
+  ] as ESTreeAST.Property;
 };
 
 export const getDocsPropertyValue = (options: Omit<FindPropertyOptions, 'name'>) => {
@@ -178,7 +183,7 @@ export const findPropertyDescriptionIndex = (options: Omit<FindPropertyOptions, 
 export const getDescriptionProperty = (options: Omit<FindPropertyOptions, 'name'>) => {
   return getDocsPropertyValue(options).properties[
     findPropertyDescriptionIndex(options)
-  ] as Property;
+  ] as ESTreeAST.Property;
 };
 
 export const getDescriptionPropertyValue = (options: Omit<FindPropertyOptions, 'name'>) => {

--- a/src/compiler/transform/story/insert-description.ts
+++ b/src/compiler/transform/story/insert-description.ts
@@ -13,10 +13,10 @@ import {
   getDescriptionPropertyValue,
 } from '#compiler/transform/shared/description';
 
+import type { ESTreeAST } from '#parser/ast';
 import type { extractStoriesNodesFromExportDefaultFn } from '#parser/extract/compiled/stories';
 import { getStoryPropsObjectExpression } from '#parser/extract/compiled/story';
 import type { SvelteASTNodes } from '#parser/extract/svelte/nodes';
-import type { Literal, Property } from 'estree';
 
 interface Params {
   nodes: {
@@ -98,8 +98,8 @@ export function insertStoryHTMLCommentAsDescription(params: Params) {
   ) {
     const propertyName = storyPropsObjectExpression.properties.find(
       (p) => p.type === 'Property' && p.key.type === 'Literal' && p.key.value === 'name'
-    ) as Property;
-    const name = (propertyName.value as Literal).value;
+    ) as ESTreeAST.Property;
+    const name = (propertyName.value as ESTreeAST.Literal).value;
     logger.warn(
       dedent`
         Svelte CSF:

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs/promises';
 
-import { combineTags } from '@storybook/csf';
 import type { IndexInput, Indexer } from '@storybook/types';
 import { preprocess } from 'svelte/compiler';
 

--- a/src/parser/analyse/define-meta/component-identifier.ts
+++ b/src/parser/analyse/define-meta/component-identifier.ts
@@ -1,5 +1,4 @@
-import type { Identifier } from 'estree';
-
+import type { ESTreeAST } from '#parser/ast';
 import { extractDefineMetaPropertiesNodes } from '#parser/extract/svelte/define-meta';
 import type { SvelteASTNodes } from '#parser/extract/svelte/nodes';
 import { InvalidComponentValueError } from '#utils/error/parser/analyse/define-meta';
@@ -9,7 +8,7 @@ interface Params {
   filename?: string;
 }
 
-export function getDefineMetaComponentValue(params: Params): Identifier | undefined {
+export function getDefineMetaComponentValue(params: Params): ESTreeAST.Identifier | undefined {
   const { nodes, filename } = params;
   const { component } = extractDefineMetaPropertiesNodes({
     nodes,

--- a/src/parser/analyse/define-meta/meta-identifier.ts
+++ b/src/parser/analyse/define-meta/meta-identifier.ts
@@ -1,5 +1,4 @@
-import type { Identifier } from 'estree';
-
+import type { ESTreeAST } from '#parser/ast';
 import type { SvelteASTNodes } from '#parser/extract/svelte/nodes';
 import {
   NoDestructuredDefineMetaCallError,
@@ -11,7 +10,7 @@ interface Params {
   filename?: string;
 }
 
-export function getMetaIdentifier(params: Params): Identifier {
+export function getMetaIdentifier(params: Params): ESTreeAST.Identifier {
   const { node, filename } = params;
   const { declarations } = node;
   const { id } = declarations[0];

--- a/src/parser/analyse/define-meta/properties.ts
+++ b/src/parser/analyse/define-meta/properties.ts
@@ -1,5 +1,4 @@
-import type { Property } from 'estree';
-
+import type { ESTreeAST } from '#parser/ast';
 import {
   ArrayElementNotStringError,
   NoArrayExpressionError,
@@ -7,7 +6,7 @@ import {
 } from '#utils/error/parser/analyse/define-meta';
 
 interface GetStringOptions {
-  node: Property;
+  node: ESTreeAST.Property;
   filename: string;
 }
 
@@ -28,7 +27,7 @@ export function getPropertyStringValue(options: GetStringOptions) {
 }
 
 interface GetArrayOfStringOptions {
-  node: Property;
+  node: ESTreeAST.Property;
   filename: string;
 }
 

--- a/src/parser/analyse/story/attributes.ts
+++ b/src/parser/analyse/story/attributes.ts
@@ -1,5 +1,4 @@
-import type { Attribute, Component } from 'svelte/compiler';
-
+import type { SvelteAST } from '#parser/ast';
 import {
   AttributeNotArrayError,
   AttributeNotArrayOfStringsError,
@@ -7,9 +6,9 @@ import {
 } from '#utils/error/parser/analyse/story';
 
 interface Params {
-  node: Attribute | undefined;
+  node: SvelteAST.Attribute | undefined;
   filename?: string;
-  component: Component;
+  component: SvelteAST.Component;
 }
 
 export function getStringValueFromAttribute(params: Params) {

--- a/src/parser/analyse/story/attributes/identifiers.ts
+++ b/src/parser/analyse/story/attributes/identifiers.ts
@@ -1,7 +1,5 @@
-import type { Attribute, Component } from 'svelte/compiler';
-
-import { getStringValueFromAttribute } from '../attributes';
-
+import { getStringValueFromAttribute } from '#parser/analyse/story/attributes';
+import type { SvelteAST } from '#parser/ast';
 import type { SvelteASTNodes } from '#parser/extract/svelte/nodes';
 import { extractStoryAttributesNodes } from '#parser/extract/svelte/story/attributes';
 import { isValidVariableName, storyNameToExportName } from '#utils/identifier-utils';
@@ -17,10 +15,10 @@ type StoryIdentifiers = {
 };
 
 interface GetIdentifiersParams {
-  nameNode?: Attribute | undefined;
-  exportNameNode?: Attribute | undefined;
+  nameNode?: SvelteAST.Attribute | undefined;
+  exportNameNode?: SvelteAST.Attribute | undefined;
   filename?: string;
-  component: Component;
+  component: SvelteAST.Component;
 }
 
 export function getStoryIdentifiers(options: GetIdentifiersParams): StoryIdentifiers {

--- a/src/parser/analyse/story/children.ts
+++ b/src/parser/analyse/story/children.ts
@@ -1,6 +1,7 @@
 import dedent from 'dedent';
-import type { Component, SnippetBlock } from 'svelte/compiler';
 
+import { getDefineMetaComponentValue } from '#parser/analyse/define-meta/component-identifier';
+import type { SvelteAST } from '#parser/ast';
 import type { extractSvelteASTNodes } from '#parser/extract/svelte/nodes';
 import { extractStoryChildrenSnippetBlock } from '#parser/extract/svelte/story/children';
 import {
@@ -8,11 +9,9 @@ import {
   findStoryAttributeChildrenSnippetBlock,
 } from '#parser/extract/svelte/snippet-block';
 
-import { getDefineMetaComponentValue } from '#parser/analyse/define-meta/component-identifier';
-
 interface Params {
   nodes: {
-    component: Component;
+    component: SvelteAST.Component;
     svelte: Awaited<ReturnType<typeof extractSvelteASTNodes>>;
   };
   originalCode: string;
@@ -148,7 +147,7 @@ export function getStoryChildrenRawCode(params: Params): string {
  * <Component {...args } />
  * ```
  */
-function getSnippetBlockBodyRawCode(originalCode: string, node: SnippetBlock) {
+function getSnippetBlockBodyRawCode(originalCode: string, node: SvelteAST.SnippetBlock) {
   const { body } = node;
   const { nodes } = body;
   const firstNode = nodes[0];

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -1,4 +1,5 @@
-import { compile, type Root } from 'svelte/compiler';
+import type * as ESTreeAST from 'estree';
+import { compile, type AST as SvelteAST } from 'svelte/compiler';
 
 interface GetSvelteASTOptions {
   code: string;
@@ -7,10 +8,12 @@ interface GetSvelteASTOptions {
 
 export function getSvelteAST(options: GetSvelteASTOptions) {
   const { filename, code } = options;
-  const { ast }: { ast: Root } = compile(code, {
+  const { ast }: { ast: SvelteAST.Root } = compile(code, {
     filename,
     modernAst: true,
   });
 
   return ast;
 }
+
+export type { SvelteAST, ESTreeAST };

--- a/src/parser/extract/compiled/stories.ts
+++ b/src/parser/extract/compiled/stories.ts
@@ -1,14 +1,15 @@
-import type { CallExpression, ExpressionStatement, Node } from 'estree';
 import type { Visitors } from 'zimmerframe';
 
 import type { CompiledASTNodes } from './nodes';
+
+import type { ESTreeAST } from '#parser/ast';
 
 interface Params {
   nodes: CompiledASTNodes;
   filename?: string;
 }
 
-type Result = (CallExpression | ExpressionStatement)[];
+type Result = (ESTreeAST.CallExpression | ESTreeAST.ExpressionStatement)[];
 
 export async function extractStoriesNodesFromExportDefaultFn(params: Params) {
   const { walk } = await import('zimmerframe');
@@ -16,7 +17,7 @@ export async function extractStoriesNodesFromExportDefaultFn(params: Params) {
   const { nodes } = params;
   const { storiesFunctionDeclaration, storyIdentifier } = nodes;
   const state: Result = [];
-  const visitors: Visitors<Node, typeof state> = {
+  const visitors: Visitors<ESTreeAST.Node, typeof state> = {
     CallExpression(node, context) {
       const { state } = context;
 

--- a/src/parser/extract/compiled/story.ts
+++ b/src/parser/extract/compiled/story.ts
@@ -1,5 +1,4 @@
-import type { ObjectExpression } from 'estree';
-
+import type { ESTreeAST } from '#parser/ast';
 import type { extractStoriesNodesFromExportDefaultFn } from '#parser/extract/compiled/stories';
 import { NoCompiledStoryPropsObjectExpression } from '#utils/error/parser/extract/compiled';
 
@@ -25,7 +24,7 @@ interface Params {
  *   Story(node_1, { props })
  *   ```
  */
-export function getStoryPropsObjectExpression(params: Params): ObjectExpression {
+export function getStoryPropsObjectExpression(params: Params): ESTreeAST.ObjectExpression {
   const { node, filename } = params;
   if (node.type === 'CallExpression' && node.arguments[1].type === 'ObjectExpression') {
     return node.arguments[1];

--- a/src/parser/extract/svelte/define-meta.test.ts
+++ b/src/parser/extract/svelte/define-meta.test.ts
@@ -1,9 +1,8 @@
-import type { ArrayExpression, Literal } from 'estree';
 import { describe, it } from 'vitest';
 
 import { extractDefineMetaPropertiesNodes } from './define-meta';
 
-import { getSvelteAST } from '#parser/ast';
+import { getSvelteAST, type ESTreeAST } from '#parser/ast';
 import { extractSvelteASTNodes } from '#parser/extract/svelte/nodes';
 
 describe(extractDefineMetaPropertiesNodes.name, () => {
@@ -27,12 +26,14 @@ describe(extractDefineMetaPropertiesNodes.name, () => {
       properties: ['title', 'id', 'tags', 'args', 'parameters'],
     });
 
-    expect((properties.title?.value as Literal).value).toBe('My Story');
-    expect((properties.id?.value as Literal).value).toBe('custom-id');
-    expect(((properties.tags?.value as ArrayExpression).elements[0] as Literal).value).toBe(
-      'autodocs'
-    );
-    expect(((properties.tags?.value as ArrayExpression).elements[1] as Literal).value).toBe('!dev');
+    expect((properties.title?.value as ESTreeAST.Literal).value).toBe('My Story');
+    expect((properties.id?.value as ESTreeAST.Literal).value).toBe('custom-id');
+    expect(
+      ((properties.tags?.value as ESTreeAST.ArrayExpression).elements[0] as ESTreeAST.Literal).value
+    ).toBe('autodocs');
+    expect(
+      ((properties.tags?.value as ESTreeAST.ArrayExpression).elements[1] as ESTreeAST.Literal).value
+    ).toBe('!dev');
     expect(properties.args).toBeUndefined();
     expect(properties.parameters).toBeUndefined();
   });

--- a/src/parser/extract/svelte/define-meta.ts
+++ b/src/parser/extract/svelte/define-meta.ts
@@ -1,5 +1,4 @@
-import type { ObjectExpression, Property } from 'estree';
-
+import type { ESTreeAST } from '#parser/ast';
 import type { SvelteASTNodes } from '#parser/extract/svelte/nodes';
 import type { CompiledASTNodes } from '#parser/extract/compiled/nodes';
 
@@ -13,7 +12,7 @@ interface Options<Properties extends Array<keyof Meta<Cmp>>> {
 }
 
 type Result<Properties extends Array<keyof Meta<Cmp>>> = Partial<{
-  [Key in Properties[number]]: Property;
+  [Key in Properties[number]]: ESTreeAST.Property;
 }>;
 
 /**
@@ -47,7 +46,7 @@ export function extractDefineMetaPropertiesNodes<const Properties extends Array<
  */
 export function getDefineMetaFirstArgumentObjectExpression(
   options: Pick<Options<Array<keyof Meta<Cmp>>>, 'filename' | 'nodes'>
-): ObjectExpression {
+): ESTreeAST.ObjectExpression {
   const { nodes, filename } = options;
   const { defineMetaVariableDeclaration, defineMetaImport } = nodes;
   const { declarations } = defineMetaVariableDeclaration;

--- a/src/parser/extract/svelte/fragment-nodes.ts
+++ b/src/parser/extract/svelte/fragment-nodes.ts
@@ -1,15 +1,16 @@
-import type { Comment, Component, Fragment, SnippetBlock, SvelteNode } from 'svelte/compiler';
 import type { Visitors } from 'zimmerframe';
 
 import type { extractModuleNodes } from './module-nodes';
 import type { extractInstanceNodes } from './instance-nodes';
 
+import type { SvelteAST } from '#parser/ast';
+
 interface Result {
   storyComponents: Array<{
     /** Leading HTML comment as AST nodes which can be used as description for the story. */
-    comment?: Comment;
+    comment?: SvelteAST.Comment;
     /** '<Story>' component AST node. */
-    component: Component;
+    component: SvelteAST.Component;
   }>;
   /**
    * "First level" _(at the root of fragment)_ snippet blocks AST nodes, which can be used for further transformation.
@@ -19,11 +20,11 @@ interface Result {
    * Based on either `setTemplate` call,
    * or by passing `children` as prop from the outer Svelte snippet block definition - e.g. `Story children={template1} />`.
    */
-  snippetBlocks: SnippetBlock[];
+  snippetBlocks: SvelteAST.SnippetBlock[];
 }
 
 interface Params {
-  fragment: Fragment;
+  fragment: SvelteAST.Fragment;
   filename?: string;
   instanceNodes: Awaited<ReturnType<typeof extractInstanceNodes>>;
   moduleNodes: Awaited<ReturnType<typeof extractModuleNodes>>;
@@ -40,14 +41,14 @@ export async function extractFragmentNodes(params: Params): Promise<Result> {
   const { fragment, moduleNodes } = params;
   const { storyIdentifier } = moduleNodes;
 
-  let latestComment: Comment | undefined;
+  let latestComment: SvelteAST.Comment | undefined;
 
   const state: Result = {
     storyComponents: [],
     snippetBlocks: [],
   };
 
-  const visitors: Visitors<SvelteNode, typeof state> = {
+  const visitors: Visitors<SvelteAST.SvelteNode, typeof state> = {
     Comment(node, { next }) {
       latestComment = node;
       next();

--- a/src/parser/extract/svelte/instance-nodes.test.ts
+++ b/src/parser/extract/svelte/instance-nodes.test.ts
@@ -1,10 +1,9 @@
-import type { Identifier } from 'estree';
 import { describe, expect, it } from 'vitest';
 
 import { extractInstanceNodes } from './instance-nodes';
 import { extractModuleNodes } from './module-nodes';
 
-import { getSvelteAST } from '#parser/ast';
+import { getSvelteAST, type ESTreeAST } from '#parser/ast';
 
 describe(extractInstanceNodes.name, () => {
   it("extract 'setTemplateCall' correctly when used", async () => {
@@ -29,7 +28,9 @@ describe(extractInstanceNodes.name, () => {
     expect(instanceNodes).toHaveProperty('setTemplateCall');
     expect(instanceNodes.setTemplateCall).toBeDefined();
     expect(instanceNodes.setTemplateCall?.arguments).toHaveLength(1);
-    expect((instanceNodes.setTemplateCall?.arguments[0] as Identifier).name).toBe('render');
+    expect((instanceNodes.setTemplateCall?.arguments[0] as ESTreeAST.Identifier).name).toBe(
+      'render'
+    );
   });
 
   it("extract 'setTemplateCall' correctly when NOT used", async () => {

--- a/src/parser/extract/svelte/instance-nodes.ts
+++ b/src/parser/extract/svelte/instance-nodes.ts
@@ -1,15 +1,15 @@
-import type { CallExpression } from 'estree';
-import type { Root, SvelteNode } from 'svelte/compiler';
 import type { Visitors } from 'zimmerframe';
 
 import type { extractModuleNodes } from './module-nodes';
 
+import type { ESTreeAST, SvelteAST } from '#parser/ast';
+
 interface Result {
-  setTemplateCall: CallExpression | undefined;
+  setTemplateCall: ESTreeAST.CallExpression | undefined;
 }
 
 interface Params {
-  instance: Root['instance'];
+  instance: SvelteAST.Root['instance'];
   moduleNodes: Awaited<ReturnType<typeof extractModuleNodes>>;
   filename?: string;
 }
@@ -18,7 +18,7 @@ interface Params {
  * Extract Svelte AST nodes via `svelte.compile`,
  * and from the instance tag - `<script>` _(without `context="module"`)_.
  * They are needed for further code analysis/transformation.
-	// NOTE: Is optional for the `*.stories.svelte` files to have this tag.
+  // NOTE: Is optional for the `*.stories.svelte` files to have this tag.
  */
 export async function extractInstanceNodes(options: Params): Promise<Result> {
   const { instance, moduleNodes } = options;
@@ -32,7 +32,7 @@ export async function extractInstanceNodes(options: Params): Promise<Result> {
   const { walk } = await import('zimmerframe');
 
   const state: Partial<Result> = {};
-  const visitors: Visitors<SvelteNode, typeof state> = {
+  const visitors: Visitors<SvelteAST.SvelteNode, typeof state> = {
     CallExpression(node, { state }) {
       if (node.callee.type === 'Identifier' && node.callee.name === setTemplateImport?.local.name) {
         state.setTemplateCall = node;

--- a/src/parser/extract/svelte/module-nodes.ts
+++ b/src/parser/extract/svelte/module-nodes.ts
@@ -1,8 +1,7 @@
 import pkg from '@storybook/addon-svelte-csf/package.json' with { type: 'json' };
-import type { Identifier, ImportSpecifier, VariableDeclaration } from 'estree';
-import type { Root, SvelteNode } from 'svelte/compiler';
 import type { Visitors } from 'zimmerframe';
 
+import type { ESTreeAST, SvelteAST } from '#parser/ast';
 import {
   DefaultOrNamespaceImportUsedError,
   MissingDefineMetaImportError,
@@ -22,26 +21,26 @@ interface Result {
    * Import specifier for `defineMeta` imported from this addon package.
    * Could be renamed - e.g. `import { defineMeta as df } from "@storybook/addon-svelte-csf"`
    */
-  defineMetaImport: ImportSpecifier;
+  defineMetaImport: ESTreeAST.ImportSpecifier;
   /**
    * Import specifier for `setTemplate` imported from this addon package.
    * Could be renamed - e.g. `import { setTemplate as st } from "@storybook/addon-svelte-csf"`
    */
-  setTemplateImport: ImportSpecifier | undefined;
+  setTemplateImport: ESTreeAST.ImportSpecifier | undefined;
   /**
    * Variable declaration: `const { Story } = defineMeta({ })`
    * Could be destructured with rename - e.g. `const { Story: S } = defineMeta({ ... })`
    */
-  defineMetaVariableDeclaration: VariableDeclaration;
+  defineMetaVariableDeclaration: ESTreeAST.VariableDeclaration;
   /**
    * An identifier for the addon's component `<Story />`.
    * It could be destructured with rename - e.g. `const { Story: S } = defineMeta({ ... })`
    */
-  storyIdentifier: Identifier;
+  storyIdentifier: ESTreeAST.Identifier;
 }
 
 interface Params {
-  module: Root['module'];
+  module: SvelteAST.Root['module'];
   filename?: string;
 }
 
@@ -60,7 +59,7 @@ export async function extractModuleNodes(options: Params): Promise<Result> {
   const { walk } = await import('zimmerframe');
 
   const state: Partial<Result> = {};
-  const visitors: Visitors<SvelteNode, typeof state> = {
+  const visitors: Visitors<SvelteAST.SvelteNode, typeof state> = {
     ImportDeclaration(node, { state, visit }) {
       const { source, specifiers } = node;
 

--- a/src/parser/extract/svelte/nodes.ts
+++ b/src/parser/extract/svelte/nodes.ts
@@ -1,8 +1,8 @@
-import type { Root } from 'svelte/compiler';
-
 import { extractModuleNodes } from './module-nodes';
 import { extractFragmentNodes } from './fragment-nodes';
 import { extractInstanceNodes } from './instance-nodes';
+
+import type { SvelteAST } from '#parser/ast';
 
 /**
  * Selected nodes extracted from the Svelte AST via `svelte.compile`,
@@ -13,7 +13,7 @@ export type SvelteASTNodes = Awaited<ReturnType<typeof extractModuleNodes>> &
   Awaited<ReturnType<typeof extractInstanceNodes>>;
 
 interface Params {
-  ast: Root;
+  ast: SvelteAST.Root;
   filename?: string;
 }
 

--- a/src/parser/extract/svelte/snippet-block.ts
+++ b/src/parser/extract/svelte/snippet-block.ts
@@ -1,5 +1,4 @@
-import type { Component, SnippetBlock } from 'svelte/compiler';
-
+import type { SvelteAST } from '#parser/ast';
 import type { SvelteASTNodes } from '#parser/extract/svelte/nodes';
 import { extractStoryAttributesNodes } from '#parser/extract/svelte/story/attributes';
 
@@ -25,7 +24,7 @@ import {
  * which was referenced by the attribute `children`. Following example above - it would be snippet `myTemplate`.
  */
 export function findStoryAttributeChildrenSnippetBlock(options: {
-  component: Component;
+  component: SvelteAST.Component;
   nodes: SvelteASTNodes;
   filename?: string;
 }) {
@@ -73,7 +72,7 @@ export function findStoryAttributeChildrenSnippetBlock(options: {
 export function findSetTemplateSnippetBlock(options: {
   nodes: SvelteASTNodes;
   filename?: string;
-}): SnippetBlock | undefined {
+}): SvelteAST.SnippetBlock | undefined {
   const { nodes, filename } = options;
   const { setTemplateCall } = nodes;
 
@@ -106,7 +105,7 @@ function findSnippetBlockByName(options: {
    */
   name: string;
   nodes: SvelteASTNodes;
-}): SnippetBlock | undefined {
+}): SvelteAST.SnippetBlock | undefined {
   const { name, nodes } = options;
   const { snippetBlocks } = nodes;
 

--- a/src/parser/extract/svelte/story/attributes.test.ts
+++ b/src/parser/extract/svelte/story/attributes.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import { extractStoryAttributesNodes } from './attributes';
 
-import { extractSvelteASTNodes } from '#parser/extract/svelte/nodes';
 import { getSvelteAST } from '#parser/ast';
+import { extractSvelteASTNodes } from '#parser/extract/svelte/nodes';
 
 describe(extractStoryAttributesNodes.name, () => {
   it("extracts '<Story />' attributes correctly", async () => {

--- a/src/parser/extract/svelte/story/attributes.ts
+++ b/src/parser/extract/svelte/story/attributes.ts
@@ -1,19 +1,19 @@
-import type { Attribute, Component } from 'svelte/compiler';
 import type { ComponentProps } from 'svelte';
 import type { EmptyObject } from 'type-fest';
 
+import type { SvelteAST } from '#parser/ast';
 import type { Cmp, Meta, StoryCmp } from '#types';
 
 type StoryAttributes = Array<keyof ComponentProps<StoryCmp<EmptyObject, Cmp, Meta<Cmp>>>>;
 
 interface Options<Attributes extends StoryAttributes> {
-  component: Component;
+  component: SvelteAST.Component;
   filename?: string;
   attributes: Attributes;
 }
 
 type Result<Attributes extends StoryAttributes> = Partial<{
-  [Key in Attributes[number]]: Attribute;
+  [Key in Attributes[number]]: SvelteAST.Attribute;
 }>;
 
 export function extractStoryAttributesNodes<const Attributes extends StoryAttributes>(

--- a/src/parser/extract/svelte/story/children.test.ts
+++ b/src/parser/extract/svelte/story/children.test.ts
@@ -2,8 +2,8 @@ import { describe, it } from 'vitest';
 
 import { extractStoryChildrenSnippetBlock } from './children';
 
-import { extractSvelteASTNodes } from '#parser/extract/svelte/nodes';
 import { getSvelteAST } from '#parser/ast';
+import { extractSvelteASTNodes } from '#parser/extract/svelte/nodes';
 
 describe(extractStoryChildrenSnippetBlock.name, () => {
   it('returns correctly AST node, when a `<Story>` compponent has a snippet block `children` inside', async ({

--- a/src/parser/extract/svelte/story/children.ts
+++ b/src/parser/extract/svelte/story/children.ts
@@ -1,6 +1,6 @@
-import type { Component, SnippetBlock } from 'svelte/compiler';
+import type { SvelteAST } from '#parser/ast';
 
-type Result = SnippetBlock | undefined;
+type Result = SvelteAST.SnippetBlock | undefined;
 
 /**
  * Extract the {@link SnippetBlock}  of the individual `<Story />` if exists.
@@ -8,7 +8,7 @@ type Result = SnippetBlock | undefined;
  * This AST node will help us in the further transformation of the `parameters.docs.source.code` on the compiled code,
  * and at runtime.
  */
-export function extractStoryChildrenSnippetBlock(component: Component): Result {
+export function extractStoryChildrenSnippetBlock(component: SvelteAST.Component): Result {
   const { fragment } = component;
   const { nodes } = fragment;
 

--- a/src/svelte.d.ts
+++ b/src/svelte.d.ts
@@ -1,0 +1,62 @@
+declare module 'svelte/compiler' {
+  import { Node as ESTreeNode } from 'estree';
+
+  declare namespace AST {
+    export interface BaseNode {
+      // NOTE: We are overriding the type here, because we don't need those
+      start?: number;
+      end?: number;
+      [propName: string]: any;
+    }
+
+    // FIXME: Those types are not exported from `svelte/compiler` - need to create an issue
+    // Temporarily manually exporting them
+
+    export type Block =
+      | AST.EachBlock
+      | AST.IfBlock
+      | AST.AwaitBlock
+      | AST.KeyBlock
+      | AST.SnippetBlock;
+
+    export type Directive =
+      | AST.AnimateDirective
+      | AST.BindDirective
+      | AST.ClassDirective
+      | AST.LetDirective
+      | AST.OnDirective
+      | AST.StyleDirective
+      | AST.TransitionDirective
+      | AST.UseDirective;
+
+    export type ElementLike =
+      | AST.Component
+      | AST.TitleElement
+      | AST.SlotElement
+      | AST.RegularElement
+      | AST.SvelteBody
+      | AST.SvelteComponent
+      | AST.SvelteDocument
+      | AST.SvelteElement
+      | AST.SvelteFragment
+      | AST.SvelteHead
+      | AST.SvelteOptionsRaw
+      | AST.SvelteSelf
+      | AST.SvelteWindow;
+
+    type Tag = AST.ExpressionTag | AST.HtmlTag | AST.ConstTag | AST.DebugTag | AST.RenderTag;
+
+    export type TemplateNode =
+      | AST.Root
+      | AST.Text
+      | Tag
+      | ElementLike
+      | AST.Attribute
+      | AST.SpreadAttribute
+      | Directive
+      | AST.Comment
+      | Block;
+
+    export type SvelteNode = ESTreeNode | TemplateNode | AST.Fragment;
+  }
+}

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,7 +1,8 @@
 import url from 'node:url';
 
 import pkg from '@storybook/addon-svelte-csf/package.json' with { type: 'json' };
-import type { Component } from 'svelte/compiler';
+
+import type { SvelteAST } from '#parser/ast';
 
 /**
  * Adopted from: {@link https://github.com/storybookjs/storybook/blob/next/code/lib/core-events/src/errors/storybook-error.ts}
@@ -93,7 +94,7 @@ export abstract class StorybookSvelteCSFError extends Error {
   /**
    * Name of the `<Story name=">...<" />` component which caused the error.
    */
-  readonly component?: Component;
+  readonly component?: SvelteAST.Component;
 
   constructor({
     filename,

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -119,26 +119,30 @@ export abstract class StorybookSvelteCSFError extends Error {
     const { attributes } = this.component;
 
     for (const attribute of attributes) {
-      if (attribute.type === 'Attribute' && attribute.name === 'name' && attribute.value !== true) {
-        if (attribute.value.type === 'ExpressionTag') {
-          return attribute.value.expression.value;
-        }
+      if (attribute.type !== 'Attribute') {
+        // NOTE: Nothing to do with this case - invalid tbh
+        continue;
+      }
 
-        if (attribute.value[0].type === 'Text') {
-          return attribute.value[0].data;
-        }
+      if (attribute.value === true) {
+        // NOTE: Nothing to do with this case - invalid tbh
+        continue;
+      }
 
-        if (attribute.value[0].type === 'Text') {
-          return attribute.value[0].data;
-        }
+      // value is SvelteAST.ExpressionTag
+      if (!Array.isArray(attribute.value)) {
+        return attribute.value.expression.value;
+      }
 
-        if (
-          attribute.value[0].type === 'ExpressionTag' &&
-          attribute.value[0].expression.type === 'Literal' &&
-          typeof attribute.value[0].expression.value === 'string'
-        ) {
-          return attribute.value[0].expression.value;
-        }
+      if (attribute.value[0].type === 'Text') {
+        return attribute.value[0].data;
+      }
+
+      if (
+        attribute.value[0].expression.type === 'Literal' &&
+        typeof attribute.value[0].expression.value === 'string'
+      ) {
+        return attribute.value[0].expression.value;
       }
     }
   }

--- a/src/utils/error/parser/analyse/define-meta.ts
+++ b/src/utils/error/parser/analyse/define-meta.ts
@@ -1,13 +1,13 @@
 import { StorybookSvelteCSFError } from '#utils/error';
 import dedent from 'dedent';
-import type { ArrayExpression, Identifier, Property, VariableDeclarator } from 'estree';
+import type * as ESTreeAST from 'estree';
 
 export class InvalidComponentValueError extends StorybookSvelteCSFError {
   readonly category = StorybookSvelteCSFError.CATEGORY.parserAnalyseDefineMeta;
   readonly code = 1;
   public documentation = true;
 
-  public componentProperty: Property;
+  public componentProperty: ESTreeAST.Property;
 
   constructor({
     filename,
@@ -35,7 +35,7 @@ export class NoDestructuredDefineMetaCallError extends StorybookSvelteCSFError {
   readonly code = 2;
   public documentation = true;
 
-  public defineMetaVariableDeclarator: VariableDeclarator;
+  public defineMetaVariableDeclarator: ESTreeAST.VariableDeclarator;
 
   constructor({
     filename,
@@ -80,7 +80,7 @@ export class NoStringLiteralError extends StorybookSvelteCSFError {
   readonly code = 4;
   public documentation = true;
 
-  readonly property: Property;
+  readonly property: ESTreeAST.Property;
 
   constructor({
     filename,
@@ -95,7 +95,7 @@ export class NoStringLiteralError extends StorybookSvelteCSFError {
 
   template(): string {
     return dedent`
-      The '${(this.property.key as Identifier).name}' passed to 'defineMeta()' must be a static string literal.
+      The '${(this.property.key as ESTreeAST.Identifier).name}' passed to 'defineMeta()' must be a static string literal.
       But it is of type '${this.property.value.type}'.
 
       This issue occurred in stories file: ${this.filepathURL}
@@ -108,7 +108,7 @@ export class NoArrayExpressionError extends StorybookSvelteCSFError {
   readonly code = 5;
   public documentation = true;
 
-  readonly property: Property;
+  readonly property: ESTreeAST.Property;
 
   constructor({
     filename,
@@ -123,7 +123,7 @@ export class NoArrayExpressionError extends StorybookSvelteCSFError {
 
   template(): string {
     return dedent`
-      The '${(this.property.key as Identifier).name}' passed to 'defineMeta()' must be a static array.
+      The '${(this.property.key as ESTreeAST.Identifier).name}' passed to 'defineMeta()' must be a static array.
       But it is of type '${this.property.value.type}'.
 
       This issue occurred in stories file: ${this.filepathURL}
@@ -136,8 +136,8 @@ export class ArrayElementNotStringError extends StorybookSvelteCSFError {
   readonly code = 6;
   public documentation = true;
 
-  readonly property: Property;
-  readonly element: ArrayExpression['elements'][number];
+  readonly property: ESTreeAST.Property;
+  readonly element: ESTreeAST.ArrayExpression['elements'][number];
 
   constructor({
     filename,
@@ -155,7 +155,7 @@ export class ArrayElementNotStringError extends StorybookSvelteCSFError {
 
   template(): string {
     return dedent`
-      All entries in the '${(this.property.key as Identifier).name}' property passed to 'defineMeta()' must be static strings.
+      All entries in the '${(this.property.key as ESTreeAST.Identifier).name}' property passed to 'defineMeta()' must be static strings.
       One of the elements is not a string but is instead of type '${this.element?.type}'.
 
       This issue occurred in stories file: ${this.filepathURL}

--- a/src/utils/error/parser/analyse/story.ts
+++ b/src/utils/error/parser/analyse/story.ts
@@ -61,8 +61,9 @@ export class AttributeNotArrayError extends StorybookSvelteCSFError {
       return true;
     }
 
-    if (value.type === 'ExpressionTag') {
-      return value.expression.value;
+    // value is SvelteAST.ExpressionTag
+    if (!Array.isArray(value)) {
+      return (value.expression as ESTreeAST.Literal).value;
     }
 
     if (value[0].type === 'Text') {
@@ -114,8 +115,8 @@ export class AttributeNotArrayOfStringsError extends StorybookSvelteCSFError {
       return true;
     }
 
-    if (value.type === 'ExpressionTag') {
-      return value.expression.value;
+    if (!Array.isArray(value)) {
+      return (value.expression as ESTreeAST.Literal).value;
     }
 
     if (value[0].type === 'Text') {

--- a/src/utils/error/parser/analyse/story.ts
+++ b/src/utils/error/parser/analyse/story.ts
@@ -1,16 +1,15 @@
 import dedent from 'dedent';
-import type { Attribute } from 'svelte/compiler';
 
-import { StorybookSvelteCSFError } from '#utils/error';
-import type { ArrayExpression, Literal } from 'estree';
 import type { getStoryIdentifiers } from '#parser/analyse/story/attributes/identifiers';
+import type { ESTreeAST, SvelteAST } from '#parser/ast';
+import { StorybookSvelteCSFError } from '#utils/error';
 
 export class AttributeNotStringError extends StorybookSvelteCSFError {
   readonly category = StorybookSvelteCSFError.CATEGORY.parserAnalyseStory;
   readonly code = 1;
   public documentation = true;
 
-  public attribute: Attribute;
+  public attribute: SvelteAST.Attribute;
 
   constructor({
     filename,
@@ -39,7 +38,7 @@ export class AttributeNotArrayError extends StorybookSvelteCSFError {
   readonly code = 2;
   public documentation = true;
 
-  public attribute: Attribute;
+  public attribute: SvelteAST.Attribute;
 
   constructor({
     filename,
@@ -70,7 +69,7 @@ export class AttributeNotArrayError extends StorybookSvelteCSFError {
       return value[0].data;
     }
 
-    return (value[0].expression as Literal).value;
+    return (value[0].expression as ESTreeAST.Literal).value;
   }
 
   template(): string {
@@ -88,8 +87,8 @@ export class AttributeNotArrayOfStringsError extends StorybookSvelteCSFError {
   readonly code = 3;
   public documentation = true;
 
-  public attribute: Attribute;
-  public element: ArrayExpression['elements'][number];
+  public attribute: SvelteAST.Attribute;
+  public element: ESTreeAST.ArrayExpression['elements'][number];
 
   constructor({
     filename,
@@ -123,7 +122,7 @@ export class AttributeNotArrayOfStringsError extends StorybookSvelteCSFError {
       return value[0].data;
     }
 
-    return (value[0].expression as Literal).value;
+    return (value[0].expression as ESTreeAST.Literal).value;
   }
 
   template(): string {

--- a/src/utils/error/parser/extract/svelte.ts
+++ b/src/utils/error/parser/extract/svelte.ts
@@ -1,6 +1,6 @@
 import dedent from 'dedent';
-import type { Attribute } from 'svelte/compiler';
 
+import type { SvelteAST } from '#parser/ast';
 import type { SvelteASTNodes } from '#parser/extract/svelte/nodes';
 import { StorybookSvelteCSFError } from '#utils/error';
 
@@ -154,7 +154,7 @@ export class InvalidStoryChildrenAttributeError extends StorybookSvelteCSFError 
   readonly code = 7;
   public documentation = true;
 
-  public childrenAttribute: Attribute;
+  public childrenAttribute: SvelteAST.Attribute;
 
   constructor({
     filename,


### PR DESCRIPTION
To summarize, the main objective - **fix CI `check`**

## What has been done

1. Update imports & usage for types related to AST nodes.\
   I've created two types _(namespaces)_, `SvelteAST` & `ESTreeAST` that are used across entire codebase _(imported from `#parser/ast`)_.
   I figured when wrapped into two namespaces is it easier to read and to quickly see from which AST they come from.
   This project is unique for using both Svelte AST and ESTree AST, so I hope this clears possible future confusion.
2. After updating `svelte` to latest rc version _(where AST types from `svelte/compiler` are finally exposed)_,
   I could see the existing types issues related to previous PR attempts to fix breaking change in Svelte AST
   _(references: #199 #201)_. So, I solved them + refactored them a little bit with early returns. There are small logic duplications, but I didn't mind them as they are easier to read and maintain than having very long and complicated if/else statements.

## What is not included

There are only warnings left with deprecations related to `<svelte:component>` and `<script context="module">`.
I'd rather them being solved them in separate PRs.
