### PR TITLE
fix(types): Allow `Snippet` mapper with primitives to match `undefined`

### DIFF
--- a/examples/components/Button.svelte
+++ b/examples/components/Button.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import type { Snippet } from 'svelte';
   import type { HTMLButtonAttributes } from 'svelte/elements';
 
   interface Props extends HTMLButtonAttributes {
@@ -19,7 +18,7 @@
     /**
      * Content of the button
      */
-    children: Snippet;
+    children: HTMLButtonAttributes['children'];
   }
 
   const {
@@ -38,7 +37,7 @@
   style={backgroundColor ? `background-color: ${backgroundColor}` : ''}
   {...buttonProps}
 >
-  {@render children()}
+  {@render children?.()}
 </button>
 
 <style>

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,5 +1,6 @@
 import type { PlayFunctionContext } from '@storybook/types';
-import type { Component, ComponentProps } from 'svelte';
+import type { Component, ComponentProps, Snippet } from 'svelte';
+import type { Primitive } from 'type-fest/source/primitive';
 import { describe, expectTypeOf, it } from 'vitest';
 
 import type {
@@ -45,5 +46,19 @@ describe('Meta', () => {
 
     expectTypeOf(meta).toMatchTypeOf<Meta<typeof Button>>();
     expectTypeOf(meta).toMatchTypeOf<ComponentAnnotations<typeof Button>>();
+  });
+
+  it('allows using string in optional children with Snippet', () => {
+    const meta = {
+      component: Button,
+      args: {
+        children: 'optional children as string',
+      },
+    } satisfies Meta<typeof Button>;
+
+    expectTypeOf(meta.args.children).toMatchTypeOf<Snippet | Primitive>();
+    expectTypeOf<NonNullable<Meta<typeof Button>['args']>['children']>().toMatchTypeOf<
+      Snippet | Primitive
+    >();
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,9 @@ export interface SvelteStoryResult<TCmpOrArgs extends CmpOrArgs> {
 }
 
 export type MapSnippetsToAcceptPrimitives<Props extends Args> = {
-  [ArgKey in keyof Props]: Props[ArgKey] extends Snippet ? Snippet | Primitive : Props[ArgKey];
+  [ArgKey in keyof Props]: Props[ArgKey] extends Snippet | undefined
+    ? Snippet | Primitive
+    : Props[ArgKey];
 };
 
 type InferArgs<TCmpOrArgs extends CmpOrArgs> = MapSnippetsToAcceptPrimitives<


### PR DESCRIPTION
Resolves #214 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.1.8--canary.215.f10113b.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-svelte-csf@4.1.8--canary.215.f10113b.0
  # or 
  yarn add @storybook/addon-svelte-csf@4.1.8--canary.215.f10113b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
