### PR TITLE
fix(pre-transform): Move stories target component import declaration from instance to module tag

### DIFF
--- a/src/compiler/pre-transform/index.test.ts
+++ b/src/compiler/pre-transform/index.test.ts
@@ -208,6 +208,7 @@ describe(codemodLegacyNodes.name, () => {
 
     expect(print(transformed)).toMatchInlineSnapshot(`
       "<script context="module">
+      	import Button from "./Button.svelte";
       	import { defineMeta } from "@storybook/addon-svelte-csf";
       	import Button from "./Button.svelte";
 
@@ -248,6 +249,34 @@ describe(codemodLegacyNodes.name, () => {
 
       More info: https://github.com/storybookjs/addon-svelte-csf/blob/v4.1.2/ERRORS.md#SB_SVELTE_CSF_LEGACY_API_0003
       ]
+    `);
+  });
+
+  it('moves import declaration of stories target component from instance tag to module tag', async ({
+    expect,
+  }) => {
+    const code = `
+      <script context="module" lang="ts">
+        export const meta: Meta<Button> = {
+          component: Button,
+        };
+      </script>
+
+      <script>
+        import { Story } from "${pkg.name}";
+        import Button from "./Button.svelte";
+      </script>
+    `;
+
+    const ast = getSvelteAST({ code });
+    const transformed = await codemodLegacyNodes({ ast });
+
+    expect(print(transformed)).toMatchInlineSnapshot(`
+      "<script context="module" lang="ts">
+      	import Button from "./Button.svelte";
+
+      	const { Story } = defineMeta({ component: Button });
+      </script>"
     `);
   });
 });

--- a/src/compiler/pre-transform/index.test.ts
+++ b/src/compiler/pre-transform/index.test.ts
@@ -208,7 +208,6 @@ describe(codemodLegacyNodes.name, () => {
 
     expect(print(transformed)).toMatchInlineSnapshot(`
       "<script context="module">
-      	import Button from "./Button.svelte";
       	import { defineMeta } from "@storybook/addon-svelte-csf";
       	import Button from "./Button.svelte";
 
@@ -273,6 +272,7 @@ describe(codemodLegacyNodes.name, () => {
 
     expect(print(transformed)).toMatchInlineSnapshot(`
       "<script context="module" lang="ts">
+      	import { defineMeta } from "@storybook/addon-svelte-csf";
       	import Button from "./Button.svelte";
 
       	const { Story } = defineMeta({ component: Button });

--- a/src/compiler/pre-transform/index.ts
+++ b/src/compiler/pre-transform/index.ts
@@ -202,33 +202,11 @@ export async function codemodLegacyNodes(params: Params): Promise<SvelteAST.Root
       instance = instance ? (visit(instance, state) as SvelteAST.Script) : null;
 
       if (!module) {
-        const {
-          pkgImportDeclaration,
-          defineMetaFromExportConstMeta,
-          storiesComponentImportDeclaration,
-        } = state;
-
-        let body: ESTreeAST.Program['body'] = [];
-
-        // WARN: This scope is bug prone
-
-        if (pkgImportDeclaration) {
-          body.push(pkgImportDeclaration);
-        }
-
-        if (storiesComponentImportDeclaration) {
-          body.push(storiesComponentImportDeclaration);
-        }
-
-        if (defineMetaFromExportConstMeta) {
-          body.push(defineMetaFromExportConstMeta);
-        }
-
         module = createASTScript({
           module: true,
           content: {
             type: 'Program',
-            body,
+            body: [],
             sourceType: 'module',
           },
         });
@@ -301,6 +279,14 @@ export async function codemodLegacyNodes(params: Params): Promise<SvelteAST.Root
       if (state.currentScript === 'module') {
         if (state.storiesComponentImportDeclaration) {
           node.body.unshift(state.storiesComponentImportDeclaration);
+        }
+
+        if (state.pkgImportDeclaration) {
+          node.body.unshift(state.pkgImportDeclaration);
+        }
+
+        if (state.defineMetaFromExportConstMeta) {
+          node.body.push(state.defineMetaFromExportConstMeta);
         }
 
         if (state.defineMetaFromComponentMeta) {


### PR DESCRIPTION
A small refactor on the way to improve readability and finding the culprit.

What happened is that previously I forgot to push (unshift) to the instance tag body an import declaration of stories component target which was storied in the state already.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.1.8--canary.218.292516a.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-svelte-csf@4.1.8--canary.218.292516a.0
  # or 
  yarn add @storybook/addon-svelte-csf@4.1.8--canary.218.292516a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
