### PR TITLE
Fix errors at `enhanceRollupError` in Vite

### DIFF
--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -56,6 +56,12 @@ export abstract class StorybookSvelteCSFError extends Error {
    */
   readonly fromStorybook: true = true as const;
 
+  /**
+   * Any custom message to override the default error message.
+   * Vite overrides the `Error.message` property, so we support that.
+   */
+  private customMessage?: string;
+
   get fullErrorCode() {
     const paddedCode = String(this.code).padStart(4, '0');
     return `SB_SVELTE_CSF_${this.category}_${paddedCode}` as `SB_SVELTE_CSF_${this['category']}_${string}`;
@@ -74,6 +80,10 @@ export abstract class StorybookSvelteCSFError extends Error {
    * Generates the error message along with additional documentation link (if applicable).
    */
   get message() {
+    if(this.customMessage) {
+      return this.customMessage;
+    }
+
     let page: string | undefined;
 
     if (this.documentation === true) {
@@ -85,6 +95,14 @@ export abstract class StorybookSvelteCSFError extends Error {
     }
 
     return `${this.template()}${page != null ? `\n\nMore info: ${page}\n` : ''}`;
+  }
+
+  /**
+   * Allows anyone to set Error.message after creation, mimicking the native Error behavior.
+   * Vite does this sometimes.
+   */
+  set message(message: string) {
+    this.customMessage = message;
   }
 
   /**


### PR DESCRIPTION
Fixes #221 

When an error is thrown during build, Vite attempts to modify the error message with `error.message = "..."`:
https://github.com/vitejs/vite/blob/91a1acb12058d7f8ea357b7564992936eed62bc7/packages/vite/src/node/build.ts#L642

Our custom Error class didn't support that, because we add a `get message()` to the class. Adding a `set message()` too, ensures Vite doesn't thrown an error during step, so it actually is able to modify the error and throw the correct one being thrown by us.

In #221 it changes the error from:

```
=> Failed to build the preview
TypeError: Cannot set property message of  which has only a getter
    at enhanceRollupError (file://./node_modules/vite/dist/node/chunks/dep-BWSbWtLw.js:65318:15)
    at build (file://./node_modules/vite/dist/node/chunks/dep-BWSbWtLw.js:65456:5)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async build (./node_modules/@storybook/builder-vite/dist/index.js:58:230)
    at async Promise.all (index 0)
    at async Module.build2 (./node_modules/@storybook/builder-vite/dist/index.js:58:5160)
    at async Promise.all (index 0)
    at async buildStaticStandalone (./node_modules/@storybook/core/dist/core-server/index.cjs:46960:3)
    at async withTelemetry (./node_modules/@storybook/core/dist/core-server/index.cjs:47080:12)
    at async build (./node_modules/@storybook/core/dist/cli/bin/index.cjs:2841:3)
```

to the correct:

```
x Build failed in 1.12s
=> Failed to build the preview
[storybook:addon-svelte-csf-plugin-post] Duplicate exportNames found between two '<Story />' definitions in stories file: file://./tests/stories/test/Conflicts.stories.svelte

First instance: <Story name="First" exportName="First" ... />
Second instance: <Story name="First" exportName="First" ... />

This can happen when 'exportName' is implicitly derived by 'name'.
Complex names will be simplified to a PascalCased, valid JavaScript variable name,
eg. 'Some story name!!' will be converted to 'SomeStoryName'.
You can fix this collision by providing a unique 'exportName' prop with <Story exportName="SomeUniqueExportName" ... />.

More info: https://github.com/storybookjs/addon-svelte-csf/blob/v4.1.2/ERRORS.md#SB_SVELTE_CSF_PARSER_ANALYSE_STORY_PLUGIN_ERROR

file: ./tests/stories/test/Conflicts.stories.svelte
SB_SVELTE_CSF_PARSER_ANALYSE_STORY_0006 (DuplicateStoryIdentifiersError): Duplicate exportNames found between two '<Story />' definitions in stories file: file://./tests/stories/test/Conflicts.stories.svelte

First instance: <Story name="First" exportName="First" ... />
Second instance: <Story name="First" exportName="First" ... />

This can happen when 'exportName' is implicitly derived by 'name'.
Complex names will be simplified to a PascalCased, valid JavaScript variable name,
eg. 'Some story name!!' will be converted to 'SomeStoryName'.
You can fix this collision by providing a unique 'exportName' prop with <Story exportName="SomeUniqueExportName" ... />.

More info: https://github.com/storybookjs/addon-svelte-csf/blob/v4.1.2/ERRORS.md#SB_SVELTE_CSF_PARSER_ANALYSE_STORY_0006

    at getStoriesIdentifiers (./dist/parser/analyse/story/attributes/identifiers.js:56:19)
    at createAppendix (./dist/compiler/post-transform/create-appendix.js:14:30)
    at transformStoriesCode (./dist/compiler/post-transform/index.js:45:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at Object.transform (./dist/compiler/plugins.js:82:13)
    at async file://./node_modules/vite-plugin-inspect/dist/index.mjs:377:17
    at async transform (file://./node_modules/rollup/dist/es/shared/node-entry.js:18676:16)
    at async ModuleLoader.addModuleSource (file://./node_modules/rollup/dist/es/shared/node-entry.js:18892:36)
```