### PR TITLE
fix: `parameters` attribute from legacy `<Story>` being removed

### DIFF
--- a/src/compiler/pre-transform/codemods/legacy-story.test.ts
+++ b/src/compiler/pre-transform/codemods/legacy-story.test.ts
@@ -279,4 +279,59 @@ describe(transformLegacyStory.name, () => {
       </Story>"
     `);
   });
+
+  it("leaves existing Story parameters untouched", async ({
+    expect,
+  }) => {
+    const code = `
+      <script context="module">
+        import { Story } from "@storybook/addon-svelte-csf";
+      </script>
+
+      <Story
+        name="Default"
+        parameters={{ 
+          sveltekit_experimental: {
+            stores: {
+              page: {
+                data: {
+                  test: 'passed',
+                },
+              },
+              navigating: {
+                route: {
+                  id: '/storybook',
+                },
+              },
+              updated: true,
+            },
+          },
+        }}
+      >
+        <h1>{"Test"}</h1>
+      </Story>
+    `;
+    const component = await parseAndExtractSvelteNode<SvelteAST.Component>(code, 'Component');
+
+    expect(
+      print(
+        transformLegacyStory({
+          component,
+          state: { componentIdentifierName: {} },
+        })
+      )
+    ).toMatchInlineSnapshot(`
+      "<Story name="Default" parameters={{
+      	sveltekit_experimental: {
+      		stores: {
+      			page: { data: { test: 'passed' } },
+      			navigating: { route: { id: '/storybook' } },
+      			updated: true
+      		}
+      	}
+      }}>
+      	<h1>{"Test"}</h1>
+      </Story>"
+    `);
+  });
 });

--- a/src/compiler/pre-transform/codemods/legacy-story.ts
+++ b/src/compiler/pre-transform/codemods/legacy-story.ts
@@ -109,6 +109,10 @@ export function transformLegacyStory(params: Params): SvelteAST.Component {
     });
   }
 
+  if (parameters) {
+    newAttributes.push(parameters);
+  }
+
   if (tags) {
     newAttributes.push(tags);
   }


### PR DESCRIPTION
Fixes #223

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.1.8--canary.224.6c887e6.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-svelte-csf@4.1.8--canary.224.6c887e6.0
  # or 
  yarn add @storybook/addon-svelte-csf@4.1.8--canary.224.6c887e6.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
