### PR TITLE
fix: properly transform invalid identifiers

### DIFF
--- a/src/compiler/pre-transform/codemods/legacy-story.test.ts
+++ b/src/compiler/pre-transform/codemods/legacy-story.test.ts
@@ -188,6 +188,28 @@ describe(transformLegacyStory.name, () => {
     ).toMatchInlineSnapshot(`"<Story name="Default" children={someTemplate} />"`);
   });
 
+  it("transforms 'template' prop to 'children' and text expression becomes expression tag with identifier to snippet (case with invalid identifier)", async ({
+    expect,
+  }) => {
+    const code = `
+      <script context="module">
+        import { Story } from "@storybook/addon-svelte-csf";
+      </script>
+
+      <Story name="Default" template="some template with non valid idenitifier" />
+    `;
+    const component = await parseAndExtractSvelteNode<SvelteAST.Component>(code, 'Component');
+
+    expect(
+      print(
+        transformLegacyStory({
+          component,
+          state: { componentIdentifierName: {} },
+        })
+      )
+    ).toMatchInlineSnapshot(`"<Story name="Default" children={template_c0gseq} />"`);
+  });
+
   it("when directive 'let:args' is used then it wraps Story fragment with 'children' snippet block", async ({
     expect,
   }) => {
@@ -280,9 +302,7 @@ describe(transformLegacyStory.name, () => {
     `);
   });
 
-  it("leaves existing Story parameters untouched", async ({
-    expect,
-  }) => {
+  it('leaves existing Story parameters untouched', async ({ expect }) => {
     const code = `
       <script context="module">
         import { Story } from "@storybook/addon-svelte-csf";

--- a/src/compiler/pre-transform/codemods/legacy-story.ts
+++ b/src/compiler/pre-transform/codemods/legacy-story.ts
@@ -1,5 +1,3 @@
-import { camelCase } from 'es-toolkit/string';
-
 import {
   createASTArrayExpression,
   createASTAttribute,
@@ -11,6 +9,7 @@ import {
 } from '#parser/ast';
 import { InvalidTemplateAttribute } from '#utils/error/legacy-api/index';
 
+import { hashTemplateName } from '#utils/identifier-utils';
 import type { State } from '..';
 
 interface Params {
@@ -247,7 +246,7 @@ function templateToChildren(
     value: [
       createASTExpressionTag({
         type: 'Identifier',
-        name: camelCase(
+        name: hashTemplateName(
           value[0].type === 'Text'
             ? value[0].data
             : ((value[0].expression as ESTreeAST.Literal).value as string)

--- a/src/compiler/pre-transform/codemods/legacy-story.ts
+++ b/src/compiler/pre-transform/codemods/legacy-story.ts
@@ -9,7 +9,7 @@ import {
 } from '$lib/parser/ast.js';
 import { InvalidTemplateAttribute } from '$lib/utils/error/legacy-api/index.js';
 
-import { hashTemplateName } from '#utils/identifier-utils';
+import { hashTemplateName } from '$lib/utils/identifier-utils.js';
 import type { State } from '..';
 
 interface Params {

--- a/src/compiler/pre-transform/codemods/template-to-snippet.test.ts
+++ b/src/compiler/pre-transform/codemods/template-to-snippet.test.ts
@@ -20,11 +20,7 @@ describe(transformTemplateToSnippet.name, () => {
     `;
     const component = await parseAndExtractSvelteNode<SvelteAST.Component>(code, 'Component');
 
-    expect(
-      print(
-        transformTemplateToSnippet({ component })
-      )
-    ).toMatchInlineSnapshot(`
+    expect(print(transformTemplateToSnippet({ component }))).toMatchInlineSnapshot(`
       "{#snippet sb_default_template(args)}
       	<Button {...args} variant="primary" />
       {/snippet}"
@@ -43,15 +39,32 @@ describe(transformTemplateToSnippet.name, () => {
     `;
     const component = await parseAndExtractSvelteNode<SvelteAST.Component>(code, 'Component');
 
-    expect(
-      print(
-        transformTemplateToSnippet({ component })
-      )
-    ).toMatchInlineSnapshot(`
+    expect(print(transformTemplateToSnippet({ component }))).toMatchInlineSnapshot(`
 			"{#snippet coolTemplate(args)}
 				<Button {...args} variant="primary" />
 			{/snippet}"
 		`);
+  });
+
+  it("covers a case with provided prop 'id' and prop `id` not being a valid identifier", async ({
+    expect,
+  }) => {
+    const code = `
+      <script context="module" lang="ts">
+        import { Template } from "${pkg.name}";
+      </script>
+
+      <Template id="cool-template" let:args>
+        <Button {...args} variant="primary" />
+      </Template>
+    `;
+    const component = await parseAndExtractSvelteNode<SvelteAST.Component>(code, 'Component');
+
+    expect(print(transformTemplateToSnippet({ component }))).toMatchInlineSnapshot(`
+      "{#snippet template_haitqt(args)}
+      	<Button {...args} variant="primary" />
+      {/snippet}"
+    `);
   });
 
   it("works with 'let:context' directive", async ({ expect }) => {
@@ -66,11 +79,7 @@ describe(transformTemplateToSnippet.name, () => {
     `;
     const component = await parseAndExtractSvelteNode<SvelteAST.Component>(code, 'Component');
 
-    expect(
-      print(
-        transformTemplateToSnippet({ component })
-      )
-    ).toMatchInlineSnapshot(`
+    expect(print(transformTemplateToSnippet({ component }))).toMatchInlineSnapshot(`
       "{#snippet sb_default_template(_args, context)}
       	<p>{context.args}</p>
       {/snippet}"

--- a/src/compiler/pre-transform/codemods/template-to-snippet.ts
+++ b/src/compiler/pre-transform/codemods/template-to-snippet.ts
@@ -1,5 +1,6 @@
 import { getStringValueFromAttribute } from '#parser/analyse/story/attributes';
 import type { SvelteAST } from '#parser/ast';
+import { hashTemplateName } from '#utils/identifier-utils';
 
 interface Params {
   component: SvelteAST.Component;
@@ -70,7 +71,7 @@ export function transformTemplateToSnippet(params: Params): SvelteAST.SnippetBlo
     type: 'SnippetBlock',
     expression: {
       type: 'Identifier',
-      name: id ?? 'sb_default_template',
+      name: id ? hashTemplateName(id) : 'sb_default_template',
     },
     parameters,
     body: fragment,

--- a/src/utils/identifier-utils.ts
+++ b/src/utils/identifier-utils.ts
@@ -54,3 +54,23 @@ export const isValidVariableName = (str: string) => {
 
   return true;
 };
+
+/**
+ * Function to convert a non valid string template name to a valid identifier preventing
+ * clashing with other templates with similar names.
+ *
+ * Stolen with 🧡 from the svelte codebase by @paoloricciuti
+ *
+ * @param str the template name
+ * @returns a hash based on the content of the initial string which is a valid identifier
+ */
+export function hashTemplateName(str: string) {
+  if (isValidVariableName(str)) return str;
+
+  str = str.replace(/\r/g, '');
+  let hash = 5381;
+  let i = str.length;
+
+  while (i--) hash = ((hash << 5) - hash) ^ str.charCodeAt(i);
+  return `template_${(hash >>> 0).toString(36)}`;
+}


### PR DESCRIPTION
This fix the transform to handle the case where the template name is an invalid identifier.

Before it was using `camelCase` (only for the `Story` actually so that was also a bug) but the problem with `camelCase` is that it can lead to the same name from different string. For example `Modal && Trigger` and `Modal || Trigger` have the same `camelCase`.

To fix this i used a small hash function (stolen from the svelte code base) so that if the template is not a valid identifier (which needs to be to be a `Snippet`) it convert it to something like `template_skajsh` (which we don't care too much except for stack traces).

I don't know if it's a solution that you like but it works.