### PR TITLE
Support Vite 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@sveltejs/vite-plugin-svelte": "^2.0.0 || ^3.0.0",
     "svelte": "^4.0.0",
     "svelte-loader": "^3.1.2",
-    "vite": "^4.0.0 || ^5.0.0"
+    "vite": "^4.0.0 || ^5.0.0 || ^6.0.0"
   },
   "peerDependenciesMeta": {
     "@sveltejs/vite-plugin-svelte": {


### PR DESCRIPTION
This PR attempts to add Vite 6 support, which supposedly won't affect this plugin so the change should be as simple as increasing the dependency range.