### PR TITLE
Support `@sveltejs/vite-plugin-svelte` v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
   },
   "peerDependencies": {
     "@storybook/svelte": "^8.0.0",
-    "@sveltejs/vite-plugin-svelte": "^4.0.0",
+    "@sveltejs/vite-plugin-svelte": "^4.0.0 || ^5.0.0",
     "svelte": "^5.0.0",
     "vite": "^5.0.0 || ^6.0.0"
   },


### PR DESCRIPTION
Broaden peer dependency range to support the recently released v5 of @sveltejs/vite-plugin-svelte

Related: https://github.com/storybookjs/storybook/pull/29731

This is only necessary on v5 (prerelease) of this addon, because v4 (stable) requires Svelte 4, and `@sveltejs/vite-plugin-svelte` dropped support for Svelte 4 in their v3.