### PR TITLE
chore: Remove Vite plugin `post` enforcement

### DIFF
--- a/src/compiler/plugins.ts
+++ b/src/compiler/plugins.ts
@@ -57,7 +57,7 @@ export async function preTransformPlugin(): Promise<Plugin> {
   };
 }
 
-export async function postTransformPlugin(): Promise<Plugin> {
+export async function transformPlugin(): Promise<Plugin> {
   const [{ createFilter }, { loadSvelteConfig }] = await Promise.all([
     import('vite'),
     import('@sveltejs/vite-plugin-svelte'),
@@ -68,8 +68,7 @@ export async function postTransformPlugin(): Promise<Plugin> {
   const filter = createFilter(include);
 
   return {
-    name: 'storybook:addon-svelte-csf-plugin-post',
-    enforce: 'post',
+    name: 'storybook:addon-svelte-csf',
     async transform(compiledCode, id) {
       if (!filter(id)) return undefined;
 

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -1,7 +1,7 @@
 import type { StorybookConfig } from '@storybook/svelte-vite';
 import type { Options } from '@storybook/types';
 
-import { postTransformPlugin, preTransformPlugin } from '#compiler/plugins';
+import { transformPlugin, preTransformPlugin } from '#compiler/plugins';
 import { createIndexer } from '#indexer/index';
 
 export interface StorybookAddonSvelteCsFOptions extends Options {
@@ -28,7 +28,7 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (
   if (legacyTemplate) {
     plugins.unshift(await preTransformPlugin());
   }
-  plugins.push(await postTransformPlugin());
+  plugins.push(await transformPlugin());
 
   return {
     ...restConfig,


### PR DESCRIPTION
This is partial work for feature #213.

See comment: <https://github.com/storybookjs/addon-svelte-csf/issues/213#issuecomment-2523222766>

I don't expect anything to break, but I suppose it wouldn't hurt to release it and see if this actually broke for anyone. What could be possible is a order conflict with another Vite's plugin.