### PR TITLE
fix: Prevent parser indexer not letting other addon errors to throw

### DIFF
--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -9,6 +9,7 @@ import {
 } from '#utils/error/parser/extract/svelte';
 import { LegacyTemplateNotEnabledError } from '#utils/error/legacy-api/index';
 import { NoDestructuredDefineMetaCallError } from '#utils/error/parser/analyse/define-meta';
+import { isStorybookSvelteCSFError } from '#utils/error';
 
 export const createIndexer = (legacyTemplate: boolean): Indexer => ({
   test: /\.svelte$/,
@@ -37,6 +38,11 @@ export const createIndexer = (legacyTemplate: boolean): Indexer => ({
       ) {
         const { filename } = error;
         throw new LegacyTemplateNotEnabledError(filename);
+      }
+
+      // WARN: We can't use instance of `StorybookSvelteCSFError`, because is an _abstract_ class :sob:
+      if (isStorybookSvelteCSFError(error)) {
+        throw error;
       }
 
       throw new IndexerParseError();

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -15,7 +15,9 @@ export const createIndexer = (legacyTemplate: boolean): Indexer => ({
   test: /\.svelte$/,
   createIndex: async (filename, { makeTitle }) => {
     try {
-      const { meta, stories } = await parseForIndexer(filename, { legacyTemplate });
+      const { meta, stories } = await parseForIndexer(filename, {
+        legacyTemplate,
+      });
 
       return stories.map((story) => {
         return {
@@ -40,12 +42,12 @@ export const createIndexer = (legacyTemplate: boolean): Indexer => ({
         throw new LegacyTemplateNotEnabledError(filename);
       }
 
-      // WARN: We can't use instance of `StorybookSvelteCSFError`, because is an _abstract_ class :sob:
+      // WARN: We can't use `instanceof StorybookSvelteCSFError`, because is an _abstract_ class
       if (isStorybookSvelteCSFError(error)) {
         throw error;
       }
 
-      throw new IndexerParseError();
+      throw new IndexerParseError({ cause: error });
     }
   },
 });

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -39,7 +39,7 @@ export const createIndexer = (legacyTemplate: boolean): Indexer => ({
         error instanceof GetDefineMetaFirstArgumentError
       ) {
         const { filename } = error;
-        throw new LegacyTemplateNotEnabledError(filename);
+        throw new LegacyTemplateNotEnabledError(filename, { cause: error });
       }
 
       // WARN: We can't use `instanceof StorybookSvelteCSFError`, because is an _abstract_ class

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -80,7 +80,7 @@ export abstract class StorybookSvelteCSFError extends Error {
    * Generates the error message along with additional documentation link (if applicable).
    */
   get message() {
-    if(this.customMessage) {
+    if (this.customMessage) {
       return this.customMessage;
     }
 
@@ -177,4 +177,19 @@ export abstract class StorybookSvelteCSFError extends Error {
   public get quickStoryRawCodeIdentifier() {
     return `<Story name="${this.storyNameFromAttribute}" />`;
   }
+}
+
+// WARN: We can't use instance of `StorybookSvelteCSFError`, because is an _abstract_ class :sob:
+export function isStorybookSvelteCSFError(error: unknown) {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+
+  for (const key of ['category', 'code', 'data', 'documentation', 'fullErrorCode', 'template']) {
+    if (!Object.hasOwn(error, key)) {
+      return false;
+    }
+  }
+
+  return true;
 }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -126,8 +126,8 @@ export abstract class StorybookSvelteCSFError extends Error {
     },
     options?: ConstructorParameters<typeof Error>[1]
   ) {
-    super('', options);
-
+    super();
+    this.cause = options?.cause;
     this.filename = filename;
     this.component = component;
   }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -10,6 +10,7 @@ import type { SvelteAST } from '#parser/ast';
  * and modified for this addon needs.
  */
 export abstract class StorybookSvelteCSFError extends Error {
+  public static isStorybookCSFSvelteError = true;
   public static packageName = pkg.name;
   public static packageVersion = pkg.version;
 
@@ -179,17 +180,10 @@ export abstract class StorybookSvelteCSFError extends Error {
   }
 }
 
-// WARN: We can't use instance of `StorybookSvelteCSFError`, because is an _abstract_ class :sob:
-export function isStorybookSvelteCSFError(error: unknown) {
-  if (typeof error !== 'object' || error === null) {
-    return false;
-  }
-
-  for (const key of ['category', 'code', 'data', 'documentation', 'fullErrorCode', 'template']) {
-    if (!Object.hasOwn(error, key)) {
-      return false;
-    }
-  }
-
-  return true;
+// WARN: We can't use `instanceof StorybookSvelteCSFError`, because is an _abstract_ class
+export function isStorybookSvelteCSFError(error: unknown): error is StorybookSvelteCSFError {
+  return Boolean(
+    (Object.getPrototypeOf(error)?.constructor as typeof StorybookSvelteCSFError)
+      ?.isStorybookCSFSvelteError
+  );
 }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -116,14 +116,17 @@ export abstract class StorybookSvelteCSFError extends Error {
    */
   readonly component?: SvelteAST.Component;
 
-  constructor({
-    filename,
-    component: component,
-  }: {
-    filename?: StorybookSvelteCSFError['filename'];
-    component?: StorybookSvelteCSFError['component'];
-  }) {
-    super();
+  constructor(
+    {
+      filename,
+      component: component,
+    }: {
+      filename?: StorybookSvelteCSFError['filename'];
+      component?: StorybookSvelteCSFError['component'];
+    },
+    options?: ConstructorParameters<typeof Error>[1]
+  ) {
+    super('', options);
 
     this.filename = filename;
     this.component = component;

--- a/src/utils/error/legacy-api/index.ts
+++ b/src/utils/error/legacy-api/index.ts
@@ -36,8 +36,9 @@ export class LegacyTemplateNotEnabledError extends StorybookSvelteCSFError {
   readonly code = 2;
   public documentation = true;
 
-  constructor(filename?: string) {
+  constructor(filename?: string, options?: ConstructorParameters<typeof Error>[1]) {
     super({ filename });
+    this.cause = options?.cause;
   }
 
   template(): string {

--- a/src/utils/error/parser/extract/svelte.ts
+++ b/src/utils/error/parser/extract/svelte.ts
@@ -218,8 +218,8 @@ export class IndexerParseError extends StorybookSvelteCSFError {
   readonly code = 9;
   public documentation = true;
 
-  constructor() {
-    super({});
+  constructor(options?: ConstructorParameters<typeof Error>[1]) {
+    super({}, options);
   }
 
   template() {


### PR DESCRIPTION
Following [thread](https://discord.com/channels/486522875931656193/1316869674608099430) on Discord.

The culprit was that `try { ... } catch(error) { }` did not allow other _(than those hand-picked ones)_ errors from this addon to throw.
