### PR TITLE
Pre-optimize internal modules

### DIFF
--- a/src/compiler/plugins.ts
+++ b/src/compiler/plugins.ts
@@ -69,6 +69,13 @@ export async function transformPlugin(): Promise<Plugin> {
 
   return {
     name: 'storybook:addon-svelte-csf',
+    config() {
+      return {
+        optimizeDeps: {
+          include: ['@storybook/addon-svelte-csf/internal/create-runtime-stories'],
+        }
+      }
+    },
     async transform(compiledCode, id) {
       if (!filter(id)) return undefined;
 


### PR DESCRIPTION
Gets rid of that annoying message (and reload):

```
22:03:26 [vite] ✨ new dependencies optimized: @storybook/addon-svelte-csf/internal/create-runtime-stories
22:03:26 [vite] ✨ optimized dependencies changed. reloading
```