### PR TITLE
Fix legacy API template hook not running before Svelte in Vitest

### DIFF
--- a/src/compiler/plugins.ts
+++ b/src/compiler/plugins.ts
@@ -31,28 +31,31 @@ export async function preTransformPlugin(): Promise<Plugin> {
   return {
     name: 'storybook:addon-svelte-csf-legacy-api-support',
     enforce: 'pre',
-    async transform(code, id) {
-      if (!filter(id)) return undefined;
+    transform: {
+      order: 'pre',
+      async handler(code, id) {
+        if (!filter(id)) return undefined;
 
-      const svelteAST = getSvelteAST({ code, filename: id });
-      const transformedSvelteAST = await codemodLegacyNodes({
-        ast: svelteAST,
-        filename: id,
-      });
+        const svelteAST = getSvelteAST({ code, filename: id });
+        const transformedSvelteAST = await codemodLegacyNodes({
+          ast: svelteAST,
+          filename: id,
+        });
 
-      let magicCode = new MagicString(code);
+        let magicCode = new MagicString(code);
 
-      magicCode.overwrite(0, code.length - 1, print(transformedSvelteAST));
+        magicCode.overwrite(0, code.length - 1, print(transformedSvelteAST));
 
-      const stringifiedMagicCode = magicCode.toString();
+        const stringifiedMagicCode = magicCode.toString();
 
-      return {
-        code: stringifiedMagicCode,
-        map: magicCode.generateMap({ hires: true, source: id }),
-        meta: {
-          _storybook_csf_pre_transform: stringifiedMagicCode,
-        },
-      };
+        return {
+          code: stringifiedMagicCode,
+          map: magicCode.generateMap({ hires: true, source: id }),
+          meta: {
+            _storybook_csf_pre_transform: stringifiedMagicCode,
+          },
+        };
+      },
     },
   };
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@
 import { defineConfig } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import inspect from 'vite-plugin-inspect';
+import path from 'path';
 
 export default defineConfig({
   plugins: [
@@ -12,4 +13,10 @@ export default defineConfig({
       build: true,
     }),
   ],
+  resolve: {
+    alias: {
+      // This is already set up in svelte.config.js, but we need it explicitly here for vitest
+      $lib: path.resolve(__dirname, 'src'),
+    },
+  },
 });

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,18 +1,9 @@
-import { defineWorkspace, mergeConfig } from 'vitest/config';
+import { defineWorkspace } from 'vitest/config';
 import { storybookTest } from '@storybook/experimental-addon-test/vitest-plugin';
-import path from 'path';
-import { svelte } from '@sveltejs/vite-plugin-svelte';
-import inspect from 'vite-plugin-inspect';
 
 export default defineWorkspace([
   {
     extends: './vite.config.ts',
-    resolve: {
-      alias: {
-        // This is already set up in svelte.config.js, but we need it explicitly here for vitest
-        $lib: path.resolve(__dirname, 'src'),
-      },
-    },
     test: {
       name: 'unit',
       dir: './src/',
@@ -21,24 +12,12 @@ export default defineWorkspace([
     },
   },
   {
-    // extends: './vite.config.ts', 👈 commented out
+    extends: './vite.config.ts',
     plugins: [
-      storybookTest({
-        storybookScript: 'pnpm run storybook --no-open',
-      }),
-      // 👆 BEFORE svelte plugin
-      svelte(),
-      inspect({
-        dev: true,
-        build: true,
-      }),
+        storybookTest({
+          storybookScript: 'pnpm run storybook --no-open',
+        }),
     ],
-    resolve: {
-      alias: {
-        // This is already set up in svelte.config.js, but we need it explicitly here for vitest
-        $lib: path.resolve(__dirname, 'src'),
-      },
-    },
     test: {
       name: 'storybook',
       browser: {


### PR DESCRIPTION
Fixes #262

Apply [a hook-level `'pre'` ordering property](rollupjs.org/plugin-development#build-hooks) to the `storybook:addon-svelte-csf-legacy-api-support` plugin, always ensuring it runs before the Svelte vite plugin even when it's later in the plugin list.

Thanks to @dominikg for the suggestion!