### PR TITLE
Fix destructured mount in play

### DIFF
--- a/examples/Button.stories.svelte
+++ b/examples/Button.stories.svelte
@@ -7,6 +7,7 @@
   } from '@storybook/addon-svelte-csf';
   import { fn } from '@storybook/test';
 
+  import type { Snippet } from 'svelte'
   import Button from './components/Button.svelte';
 
   const onclickFn = fn().mockName('onclick');
@@ -20,6 +21,7 @@
     tags: ['autodocs'],
     args: {
       onclick: onclickFn,
+      children: 'Click me' as unknown as Snippet<[]>
     },
     argTypes: {
       backgroundColor: { control: 'color' },
@@ -37,7 +39,7 @@
 </script>
 
 {#snippet template(args: Args<typeof Story>, context: StoryContext<typeof Story>)}
-  <Button {...args}>{'Click me'}</Button>
+  <Button {...args}>{args.children}</Button>
 {/snippet}
 
 <!-- Only use this sparingly as the main CTA. -->

--- a/src/runtime/create-runtime-stories.ts
+++ b/src/runtime/create-runtime-stories.ts
@@ -68,9 +68,21 @@ export const createRuntimeStories = (Stories: Component, meta: Meta<Cmp>) => {
        * The 'play' function should be delegated to the real play Story function
        * in order to be run into the component scope.
        */
-      function params(fn) { return fn.toString().match(/[^(]*\(([^)]*)/)?.slice(1) ?? [] }
-      const isMounting = params(storyObj.play).filter((p) => /\{\s*mount\s*\}/.test(p)).length != 0
-      storyObj.play = isMounting ? function ({ mount }) { return playDelegator(arguments[0]) } : (storyContext) => playDelegator(storyContext);
+      function params(fn) {
+        return (
+          fn
+            .toString()
+            .match(/[^(]*\(([^)]*)/)
+            ?.slice(1) ?? []
+        );
+      }
+      const isMounting =
+        params(storyObj.play).filter((p) => /\{.*,?\s*mount\s*,?.*\}/.test(p)).length != 0;
+      storyObj.play = isMounting
+        ? function ({ mount }) {
+            return playDelegator(arguments[0]);
+          }
+        : (storyContext) => playDelegator(storyContext);
       function playDelegator(storyContext) {
         const delegate = storyContext.playFunction?.__play;
 
@@ -80,7 +92,7 @@ export const createRuntimeStories = (Stories: Component, meta: Meta<Cmp>) => {
 
         // @ts-expect-error WARN: It should not affect user perspective- the problem lies in this addon's type `SvelteRenderer` missing type constrains or default generic parameter type
         return play(storyContext);
-      };
+      }
     }
 
     stories[exportName] = storyObj;

--- a/src/runtime/create-runtime-stories.ts
+++ b/src/runtime/create-runtime-stories.ts
@@ -82,7 +82,7 @@ export const createRuntimeStories = (Stories: Component, meta: Meta<Cmp>) => {
         ? function ({ mount }) {
             return playDelegator(arguments[0]);
           }
-        : (storyContext) => playDelegator(storyContext);
+        : playDelegator;
       function playDelegator(storyContext) {
         const delegate = storyContext.playFunction?.__play;
 

--- a/src/runtime/create-runtime-stories.ts
+++ b/src/runtime/create-runtime-stories.ts
@@ -68,7 +68,10 @@ export const createRuntimeStories = (Stories: Component, meta: Meta<Cmp>) => {
        * The 'play' function should be delegated to the real play Story function
        * in order to be run into the component scope.
        */
-      storyObj.play = (storyContext) => {
+      function params(fn) { return fn.toString().match(/[^(]*\(([^)]*)/)?.slice(1) ?? [] }
+      const isMounting = params(storyObj.play).filter((p) => /\{\s*mount\s*\}/.test(p)).length != 0
+      storyObj.play = isMounting ? function ({ mount }) { return playDelegator(arguments[0]) } : (storyContext) => playDelegator(storyContext);
+      function playDelegator(storyContext) {
         const delegate = storyContext.playFunction?.__play;
 
         if (delegate) {

--- a/tests/stories/Mountable.stories.svelte
+++ b/tests/stories/Mountable.stories.svelte
@@ -1,0 +1,55 @@
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import { within, expect, fn } from '@storybook/test';
+
+  import Mountable from './stories/Mountable.svelte';
+
+  // More on how to set up stories at: https://storybook.js.org/docs/writing-stories
+  const { Story } = defineMeta({
+    title: 'Play() mount',
+    component: Mountable,
+    tags: ['xautodocs'],
+    argTypes: {},
+    args: {
+      text: 'Mountable',
+      onMounted: fn(),
+    },
+  });
+</script>
+
+<!-- play no mount -->
+<Story
+  name="Play no mount"
+  play={async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByText('Mountable')).toBeInTheDocument();
+  }}
+></Story>
+
+<!-- play and mount only -->
+<Story
+  name="With mount only"
+  play={async ({ mount }) => {
+    console.log('Pre');
+    await mount();
+    console.log('Post');
+  }}
+></Story>
+
+<!-- play and mount -->
+<Story
+  name="With mount"
+  play={async ({ args, mount, canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // passing test does no show pre mount, so we test after mount
+    const preMountLabel = canvas.queryByText('Mountable');
+
+    await mount();
+
+    expect(preMountLabel).toBeNull(); // Here so shows in Component Test panel
+
+    expect(canvas.getByText('Mountable')).toBeInTheDocument();
+    expect(args.onMounted).toHaveBeenCalled();
+  }}
+></Story>

--- a/tests/stories/Mountable.svelte
+++ b/tests/stories/Mountable.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+
+  interface Props {
+    /** Is this the principal call to action on the page? */
+    text: string
+    /** The onclick event handler */
+    onMounted: () => void
+  }
+
+  const { text, onMounted }: Props = $props()
+
+  onMount(() => {
+    onMounted()
+  })
+</script>
+
+<div>
+  {text}
+</div>


### PR DESCRIPTION
Addresses storybookjs/addon-svelte-csf#270

First time commit to storybook and attempt to fix the svelte `play({mount})` problem.

This was a bit tricky given steep learing curve as I went "round the houses" and I'm sure I missed loads of process essentials. If so some mentoring or pointers would help.

The problem was introduced with #169. I could not find a related issue to explain the problem but I guess it's pretty obvious. Hopefully the PR doesn't break anything.

Didn't find any relevent tests but guess some should be added for new code? Here's a story @JReinhold used:

```svelte
 <Story name="With Mount" play={async ({ mount }) => {
    console.log('pre 1');
    await mount();
    console.log('post 1');
}} />
```

See comments inline in the commits