### PR TITLE
Fix preview-api dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "dependencies": {
     "@storybook/csf": "^0.1.11",
     "@storybook/docs-tools": "^8.0.0",
+    "@storybook/preview-api": "8.5.0-beta.11",
     "@storybook/types": "^8.0.0",
     "dedent": "^1.5.3",
     "es-toolkit": "^1.26.1",
@@ -68,7 +69,6 @@
     "@storybook/addon-essentials": "8.5.0-beta.11",
     "@storybook/eslint-config-storybook": "^4.0.0",
     "@storybook/experimental-addon-test": "^8.5.0-beta.11",
-    "@storybook/preview-api": "8.5.0-beta.11",
     "@storybook/svelte": "8.5.0-beta.11",
     "@storybook/svelte-vite": "8.5.0-beta.11",
     "@storybook/test": "8.5.0-beta.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       '@storybook/docs-tools':
         specifier: 8.5.0-beta.11
         version: 8.5.0-beta.11(storybook@8.5.0-beta.11(prettier@3.3.2))
+      '@storybook/preview-api':
+        specifier: 8.5.0-beta.11
+        version: 8.5.0-beta.11(storybook@8.5.0-beta.11(prettier@3.3.2))
       '@storybook/types':
         specifier: 8.5.0-beta.11
         version: 8.5.0-beta.11(storybook@8.5.0-beta.11(prettier@3.3.2))
@@ -59,9 +62,6 @@ importers:
       '@storybook/experimental-addon-test':
         specifier: ^8.5.0-beta.11
         version: 8.5.0-beta.11(@vitest/browser@2.1.4)(@vitest/runner@2.1.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.5.0-beta.11(prettier@3.3.2))(vitest@2.1.4)
-      '@storybook/preview-api':
-        specifier: 8.5.0-beta.11
-        version: 8.5.0-beta.11(storybook@8.5.0-beta.11(prettier@3.3.2))
       '@storybook/svelte':
         specifier: 8.5.0-beta.11
         version: 8.5.0-beta.11(storybook@8.5.0-beta.11(prettier@3.3.2))(svelte@5.1.4)


### PR DESCRIPTION
Used here so it needs to be a regular dependency or peer dependency or pre-bundled:

https://github.com/storybookjs/addon-svelte-csf/blob/next/src/runtime/emit-code.ts#L2