### PR TITLE
Fix not working with `getAbsolutePath`

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "files": [
     "dist/**/*",
     "!dist/**/*.test.*",
+    "preset.js",
     "README.md"
   ],
   "scripts": {

--- a/preset.js
+++ b/preset.js
@@ -1,0 +1,1 @@
+export * from './dist/preset.js';


### PR DESCRIPTION
Fixes #174

Added a root `preset.js` file, albeit slightly different than usual, because this is an ESM package.

I've tested that this works with and without the `getAbsolutePath` wrapper, in a pnpm monorepo and in a regular pnpm repo.