### PR TITLE
Fix story `children` not overriding `args.children` 

### DIFF
--- a/src/runtime/Story.svelte
+++ b/src/runtime/Story.svelte
@@ -150,7 +150,7 @@
     {#if asChild || isLegacyStory}
       {@render children()}
     {:else if renderer.storyContext.component}
-      <renderer.storyContext.component {children} {...renderer.args} />
+      <renderer.storyContext.component {...renderer.args} {children} />
     {:else}
       {@render children()}
     {/if}


### PR DESCRIPTION
https://github.com/storybookjs/addon-svelte-csf/pull/268 uncovered a bug: if you pass in `children` via args _and_ you pass in `children` to the `Story`, the args will actually win even though the Story's `children` should.

Svelte would fail with _"snippet2 is not a function"_, because it would try to render `args.children` which was just a string.