### PR TITLE
Fix reading `rawCode` from undefined `__svelteCsf`

### DIFF
--- a/src/runtime/emit-code.ts
+++ b/src/runtime/emit-code.ts
@@ -47,7 +47,7 @@ export const emitCode = (params: Params) => {
 const skipSourceRender = (context: Params['storyContext']) => {
   const sourceParams = context?.parameters.docs?.source;
   const isArgsStory = context?.parameters.__isArgsStory;
-  const rawCode = context?.parameters.__svelteCsf.rawCode;
+  const rawCode = context?.parameters.__svelteCsf?.rawCode;
 
   if (!rawCode) {
     return true;


### PR DESCRIPTION
In Svelte v5.35.1 https://github.com/sveltejs/svelte/pull/16255 introduced a change to the compiled output of a component. This change broke how we're injecting `parameters.__svelteCsf.rawCode` into stories.

For now we're just silently handling the situation where that is now `undefined` at runtime, to not block rendering or testing a story.

This does mean however that generated code snippets are now broken in Svelte 5.35.1 and up, and we need a longer term fix for that.

Filed in https://github.com/storybookjs/addon-svelte-csf/issues/320