### PR TITLE
fix: load Svelte config once in the story indexer

### DIFF
--- a/.changeset/witty-otters-search.md
+++ b/.changeset/witty-otters-search.md
@@ -1,0 +1,5 @@
+---
+'@storybook/addon-svelte-csf': patch
+---
+
+Load the Svelte config once per process in the story indexer instead of re-running the config lookup for every `.stories.svelte` file, eliminating redundant config-file scans and the resulting repeated "no Svelte config found" log lines.

--- a/src/indexer/parser.test.ts
+++ b/src/indexer/parser.test.ts
@@ -1,0 +1,44 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { beforeEach, describe, it, vi } from 'vitest';
+
+const loadSvelteConfig = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock('@sveltejs/vite-plugin-svelte', () => ({ loadSvelteConfig }));
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const storyFile = resolve(currentDir, '../../examples/Button.stories.svelte');
+
+describe('parseForIndexer', () => {
+  beforeEach(() => {
+    // The config cache lives in module scope — reset modules so each test starts cold
+    vi.resetModules();
+    loadSvelteConfig.mockClear();
+  });
+
+  it('loads the Svelte config once across multiple story files', async ({ expect }) => {
+    const { parseForIndexer } = await import('./parser.js');
+    const files = [storyFile, resolve(currentDir, '../../examples/ExportName.stories.svelte')];
+
+    for (const file of files) {
+      await parseForIndexer(file, { legacyTemplate: false });
+    }
+
+    expect(loadSvelteConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries the Svelte config lookup after a failure instead of caching it', async ({
+    expect,
+  }) => {
+    const { parseForIndexer } = await import('./parser.js');
+    loadSvelteConfig.mockRejectedValueOnce(new Error('broken config'));
+
+    await expect(parseForIndexer(storyFile, { legacyTemplate: false })).rejects.toThrow(
+      'broken config'
+    );
+    await expect(parseForIndexer(storyFile, { legacyTemplate: false })).resolves.toBeDefined();
+
+    expect(loadSvelteConfig).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/indexer/parser.ts
+++ b/src/indexer/parser.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 
 import pkg from '@storybook/addon-svelte-csf/package.json' with { type: 'json' };
 import { preprocess } from 'svelte/compiler';
+import type { SvelteConfig } from '@sveltejs/vite-plugin-svelte';
 import type { IndexInput } from 'storybook/internal/types';
 
 import { getSvelteAST, type ESTreeAST, type SvelteAST } from '$lib/parser/ast.js';
@@ -36,18 +37,37 @@ interface Results {
   isLegacy: boolean;
 }
 
+/**
+ * The indexer runs once per `*.stories.svelte` file, while the Svelte config is per-project state.
+ * Cache the lookup so the config-file scan runs once per process instead of once per story file —
+ * without this, projects without a `svelte.config.js` get one
+ * "no Svelte config found ... using default configuration" log line per story file.
+ * Trade-off: adding a svelte.config file while `storybook dev` runs requires a restart to be picked up.
+ */
+let svelteConfigPromise: Promise<Partial<SvelteConfig> | undefined> | undefined;
+
+async function loadCachedSvelteConfig(): Promise<Partial<SvelteConfig> | undefined> {
+  svelteConfigPromise ??= import('@sveltejs/vite-plugin-svelte')
+    .then(({ loadSvelteConfig }) => loadSvelteConfig())
+    .catch((error) => {
+      // Don't cache failures (e.g. a broken svelte.config.js), so the next indexing run retries.
+      svelteConfigPromise = undefined;
+      throw error;
+    });
+  return svelteConfigPromise;
+}
+
 export async function parseForIndexer(
   filename: string,
   options: Partial<StorybookAddonSvelteCsFOptions>
 ): Promise<Results> {
-  let [code, { walk }, { loadSvelteConfig }] = await Promise.all([
+  let [code, { walk }, svelteConfig] = await Promise.all([
     fs.readFile(filename, { encoding: 'utf8' }),
     import('zimmerframe'),
-    import('@sveltejs/vite-plugin-svelte'),
+    loadCachedSvelteConfig(),
   ]);
 
   const { legacyTemplate } = options;
-  const svelteConfig = await loadSvelteConfig();
 
   if (svelteConfig?.preprocess) {
     code = (


### PR DESCRIPTION
Fixes #355

`parseForIndexer` re-ran the full Svelte config lookup for every indexed `.stories.svelte` file — re-scanning the filesystem for config candidates each time — even though the config is per-project state. In a project with 97 stories files, a single build performed the lookup 97 times (and, with no svelte.config file present, printed the "no Svelte config found" info line 98 times).

This PR caches the lookup in module scope so it runs once per process. Failures are not cached, so a broken svelte.config is retried on the next indexing run instead of requiring a restart.

Trade-off: adding a svelte.config file while `storybook dev` is running is only picked up after a restart (noted in a code comment).

Includes unit tests for the caching and the failure-retry path, and a patch changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)